### PR TITLE
Small fix for make uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ install:
 
 uninstall:
 	rm "$(DESTDIR)$(PREFIX)/bin/gnvim"
-	rm "$(DESTDIR)$(PREFIX)/share/gnvim"
+	rm -rf "$(DESTDIR)$(PREFIX)/share/gnvim"


### PR DESCRIPTION
Hello!
`sudo make uninstall` breaks with following error:
```
$ sudo make uninstall
rm "/usr/local/bin/gnvim"
rm "/usr/local/share/gnvim"
rm: cannot remove '/usr/local/share/gnvim': Is a directory
Makefile:30: recipe for target 'uninstall' failed
make: *** [uninstall] Error 1
```
I have added `-rf` to rm command in Makefile.