### PR TITLE
Add Ignore variant to RedrawEvent

### DIFF
--- a/src/nvim_bridge.rs
+++ b/src/nvim_bridge.rs
@@ -274,6 +274,7 @@ pub enum RedrawEvent {
     WildmenuHide(),
     WildmenuSelect(i64),
 
+    Ignored(String),
     Unknown(String),
 }
 
@@ -317,6 +318,7 @@ impl fmt::Display for RedrawEvent {
             RedrawEvent::WildmenuShow(..) => write!(fmt, "WildmenuShow"),
             RedrawEvent::WildmenuHide(..) => write!(fmt, "WildmenuHide"),
             RedrawEvent::WildmenuSelect(..) => write!(fmt, "WildmenuSelect"),
+            RedrawEvent::Ignored(..) => write!(fmt, "Ignored"),
             RedrawEvent::Unknown(..) => write!(fmt, "Unknown"),
         }
     }
@@ -786,6 +788,9 @@ fn parse_redraw_event(args: Vec<Value>) -> Vec<RedrawEvent> {
                     let args = unwrap_array!(args[1]);
                     let item = unwrap_i64!(args[0]);
                     RedrawEvent::WildmenuSelect(item)
+                }
+                "mouse_on" | "mouse_off" => {
+                    RedrawEvent::Ignored(cmd.to_string())
                 }
                 _ => RedrawEvent::Unknown(cmd.to_string()),
             }

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -746,6 +746,7 @@ fn handle_redraw_event(
             RedrawEvent::WildmenuSelect(item) => {
                 state.cmdline.wildmenu_select(*item);
             }
+            RedrawEvent::Ignored(_) => (),
             RedrawEvent::Unknown(e) => {
                 println!("Received unknown redraw event: {}", e);
             }


### PR DESCRIPTION
gnvim prints a lot of messages to the console about unknown events which are valid, but not handled. This adds a no-op `Ignore` variant to `RedrawEvent` to silence those messages.

Storing the event string could be useful for debugging purposes, but it's currently unused, so it's worth considering whether it should be kept