### PR TITLE
Handle guicursor blinkon property

### DIFF
--- a/src/nvim_bridge.rs
+++ b/src/nvim_bridge.rs
@@ -157,6 +157,8 @@ impl Default for CursorShape {
 
 #[derive(Default, Clone)]
 pub struct ModeInfo {
+    /// The cursor blinking period (in ms)
+    pub blink_on: u64,
     pub cursor_shape: CursorShape,
     /// The cursor's width (in percentages, from 0..1).
     pub cell_percentage: f64,
@@ -166,6 +168,9 @@ pub struct ModeInfo {
 impl ModeInfo {
     fn set(&mut self, prop: &str, val: Value) {
         match prop {
+            "blinkon" => {
+                self.blink_on = unwrap_u64!(val);
+            }
             "cursor_shape" => {
                 self.cursor_shape = CursorShape::from_string(unwrap_str!(val))
             }

--- a/src/ui/grid/context.rs
+++ b/src/ui/grid/context.rs
@@ -28,7 +28,9 @@ pub struct Context {
     pub cursor: (u64, u64),
     /// Cursor alpha color. Used to make the cursor blink.
     pub cursor_alpha: f64,
-    /// Width of the curosr.
+    /// The duration of the cursor blink
+    pub cursor_blink_on: u64,
+    /// Width of the cursor.
     pub cursor_cell_percentage: f64,
     /// Color of the cursor.
     pub cursor_color: Color,
@@ -75,6 +77,7 @@ impl Context {
 
             cursor: (0, 0),
             cursor_alpha: 1.0,
+            cursor_blink_on: 0,
             cursor_cell_percentage: 1.0,
             cursor_color: Color::from_u64(0),
             busy: false,

--- a/src/ui/grid/grid.rs
+++ b/src/ui/grid/grid.rs
@@ -402,9 +402,15 @@ impl Grid {
         let mut ctx = self.context.borrow_mut();
         let ctx = ctx.as_mut().unwrap();
 
-        ctx.cursor_alpha += 0.05;
-        if ctx.cursor_alpha > 2.0 {
-            ctx.cursor_alpha = 0.0;
+        if ctx.cursor_blink_on > 0 {
+            // Assuming a 60hz framerate
+            ctx.cursor_alpha += 100.0 / (6.0 * ctx.cursor_blink_on as f64);
+
+            if ctx.cursor_alpha > 2.0 {
+                ctx.cursor_alpha = 0.0;
+            }
+        } else {
+            ctx.cursor_alpha = 0.5;
         }
 
         let (x, y, w, h) = {
@@ -445,6 +451,7 @@ impl Grid {
         let mut ctx = self.context.borrow_mut();
         let ctx = ctx.as_mut().unwrap();
 
+        ctx.cursor_blink_on = mode.blink_on;
         ctx.cursor_cell_percentage = mode.cell_percentage;
     }
 


### PR DESCRIPTION
This is an initial effort to support setting blinking on gnvim.

For retrocompatibility, a runtime setting is added indentical to the previous effect.

To disable the blinking `set guicursor+=a:blinkon0`.

Fixes #17