### PR TITLE
Remove 'help-circle.svg' (question mark) icon from unknown autocompletions

### DIFF
--- a/src/nvim_bridge.rs
+++ b/src/nvim_bridge.rs
@@ -241,9 +241,9 @@ pub enum CompletionItemKind {
     Variable,
 }
 
-impl CompletionItemKind {
-    pub fn new_from_str(kind: &str) -> Self {
-        match kind {
+impl From<&String> for CompletionItemKind {
+    fn from(from: &String) -> Self {
+        match from.as_str() {
             "class" => CompletionItemKind::Class,
             "color" => CompletionItemKind::Color,
             "constant" => CompletionItemKind::Constant,
@@ -272,7 +272,10 @@ impl CompletionItemKind {
             _ => CompletionItemKind::Unknown,
         }
     }
-   pub fn is_unknown(&self) -> bool {
+}
+
+impl CompletionItemKind {
+    pub fn is_unknown(&self) -> bool {
         match self {
             CompletionItemKind::Unknown => true,
             _ => false,
@@ -284,6 +287,7 @@ impl CompletionItemKind {
 pub struct CompletionItem {
     pub word: String,
     pub kind: CompletionItemKind,
+    pub kind_raw: String,
     pub menu: String,
     pub info: String,
 }
@@ -748,7 +752,10 @@ fn parse_redraw_event(args: Vec<Value>) -> Vec<RedrawEvent> {
                     for item in unwrap_array!(args[0]) {
                         let item = unwrap_array!(item);
                         let word = unwrap_str!(item[0]).to_owned();
-                        let kind = CompletionItemKind::new_from_str(&unwrap_str!(item[1]).to_owned());
+                        let kind = CompletionItemKind::from(
+                            &unwrap_str!(item[1]).to_owned(),
+                        );
+                        let kind_raw = unwrap_str!(item[1]).to_owned();
                         let menu = unwrap_str!(item[2]).to_owned();
                         let info = unwrap_str!(item[3]).to_owned();
 
@@ -757,6 +764,7 @@ fn parse_redraw_event(args: Vec<Value>) -> Vec<RedrawEvent> {
                             kind,
                             menu,
                             info,
+                            kind_raw,
                         });
                     }
 

--- a/src/nvim_bridge.rs
+++ b/src/nvim_bridge.rs
@@ -241,9 +241,9 @@ pub enum CompletionItemKind {
     Variable,
 }
 
-impl From<&String> for CompletionItemKind {
-    fn from(from: &String) -> Self {
-        match from.as_str() {
+impl From<&str> for CompletionItemKind {
+    fn from(from: &str) -> Self {
+        match from {
             "class" => CompletionItemKind::Class,
             "color" => CompletionItemKind::Color,
             "constant" => CompletionItemKind::Constant,
@@ -752,9 +752,8 @@ fn parse_redraw_event(args: Vec<Value>) -> Vec<RedrawEvent> {
                     for item in unwrap_array!(args[0]) {
                         let item = unwrap_array!(item);
                         let word = unwrap_str!(item[0]).to_owned();
-                        let kind = CompletionItemKind::from(
-                            &unwrap_str!(item[1]).to_owned(),
-                        );
+                        let kind =
+                            CompletionItemKind::from(unwrap_str!(item[1]));
                         let kind_raw = unwrap_str!(item[1]).to_owned();
                         let menu = unwrap_str!(item[2]).to_owned();
                         let info = unwrap_str!(item[3]).to_owned();

--- a/src/nvim_bridge.rs
+++ b/src/nvim_bridge.rs
@@ -212,9 +212,78 @@ pub enum OptionSet {
 }
 
 #[derive(Clone)]
+pub enum CompletionItemKind {
+    Class,
+    Color,
+    Constant,
+    Constructor,
+    Enum,
+    EnumMember,
+    Event,
+    Function,
+    File,
+    Folder,
+    Field,
+    Interface,
+    Keyword,
+    Method,
+    Module,
+    Operator,
+    Property,
+    Reference,
+    Snippet,
+    Struct,
+    Text,
+    TypeParameter,
+    Unit,
+    Unknown,
+    Value,
+    Variable,
+}
+
+impl CompletionItemKind {
+    pub fn new_from_str(kind: &str) -> Self {
+        match kind {
+            "class" => CompletionItemKind::Class,
+            "color" => CompletionItemKind::Color,
+            "constant" => CompletionItemKind::Constant,
+            "constructor" => CompletionItemKind::Constructor,
+            "enum" => CompletionItemKind::Enum,
+            "enum member" => CompletionItemKind::EnumMember,
+            "event" => CompletionItemKind::Event,
+            "function" => CompletionItemKind::Function,
+            "file" => CompletionItemKind::File,
+            "folder" => CompletionItemKind::Folder,
+            "field" => CompletionItemKind::Field,
+            "interface" => CompletionItemKind::Interface,
+            "keyword" => CompletionItemKind::Keyword,
+            "method" => CompletionItemKind::Method,
+            "module" => CompletionItemKind::Module,
+            "operator" => CompletionItemKind::Operator,
+            "property" => CompletionItemKind::Property,
+            "reference" => CompletionItemKind::Reference,
+            "snippet" => CompletionItemKind::Snippet,
+            "struct" => CompletionItemKind::Struct,
+            "text" => CompletionItemKind::Text,
+            "type parameter" => CompletionItemKind::TypeParameter,
+            "unit" => CompletionItemKind::Unit,
+            "value" => CompletionItemKind::Value,
+            "variable" => CompletionItemKind::Variable,
+            _ => CompletionItemKind::Unknown,
+        }
+    }
+   pub fn is_unknown(&self) -> bool {
+        match self {
+            CompletionItemKind::Unknown => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct CompletionItem {
     pub word: String,
-    pub kind: String,
+    pub kind: CompletionItemKind,
     pub menu: String,
     pub info: String,
 }
@@ -679,7 +748,7 @@ fn parse_redraw_event(args: Vec<Value>) -> Vec<RedrawEvent> {
                     for item in unwrap_array!(args[0]) {
                         let item = unwrap_array!(item);
                         let word = unwrap_str!(item[0]).to_owned();
-                        let kind = unwrap_str!(item[1]).to_owned();
+                        let kind = CompletionItemKind::new_from_str(&unwrap_str!(item[1]).to_owned());
                         let menu = unwrap_str!(item[2]).to_owned();
                         let info = unwrap_str!(item[3]).to_owned();
 

--- a/src/ui/popupmenu/completion_item_widget.rs
+++ b/src/ui/popupmenu/completion_item_widget.rs
@@ -1,7 +1,7 @@
 use gtk;
 use gtk::prelude::*;
 
-use nvim_bridge::CompletionItem;
+use nvim_bridge::{ CompletionItem, CompletionItemKind };
 use ui::color::Color;
 
 macro_rules! icon {
@@ -20,7 +20,9 @@ pub struct CompletionItemWidgetWrap {
     /// Label displaying `menu` for this item in the list.
     pub menu: gtk::Label,
     /// Image of the item in the row.
-    pub kind: gtk::Image,
+    pub image: gtk::Image,
+    /// Kind of the item
+    pub kind: CompletionItemKind,
     /// Root container.
     pub row: gtk::ListBoxRow,
 }
@@ -28,15 +30,31 @@ pub struct CompletionItemWidgetWrap {
 impl CompletionItemWidgetWrap {
     pub fn create(
         item: CompletionItem,
+        items: &Vec<CompletionItem>,
         css_provider: &gtk::CssProvider,
         icon_fg: &Color,
         size: f64,
-        know_items_kinds: bool,
     ) -> Self {
         let margin = (size / 3.0) as i32;
 
         let grid = gtk::Grid::new();
         grid.set_column_spacing(10);
+
+        let buf = get_icon_pixbuf(&item.kind, icon_fg, size);
+        let image = match &item.kind {
+            CompletionItemKind::Unknown => {
+                // If another item in the popupmenu has a known kind,
+                // give kind_image an icon.
+                if items.iter().any(|item| !item.kind.is_unknown()) {
+                    gtk::Image::new_from_pixbuf(&buf) 
+                } else { gtk::Image::new() }
+            }
+            _ => gtk::Image::new_from_pixbuf(&buf),
+        };
+
+        // kind_image.set_tooltip_text(format!("kind: '{}'", &item.kind.get_kind()).as_str());
+        image.set_margin_start(margin);
+        grid.attach(&image, 0, 0, 1, 1);
 
         let menu = gtk::Label::new(item.menu.as_str());
         menu.set_halign(gtk::Align::End);
@@ -67,36 +85,17 @@ impl CompletionItemWidgetWrap {
         let row = gtk::ListBoxRow::new();
         row.add(&grid);
 
-        let buf = get_icon_pixbuf(&item.kind.as_str(),
-                                    icon_fg, 
-                                    size,
-                                    know_items_kinds);
-        match buf {
-            Ok(buff) => {
-                let kind = gtk::Image::new_from_pixbuf(&buff);
-                kind.set_tooltip_text(format!("kind: '{}'", item.kind).as_str());
-                kind.set_margin_start(margin);
-                grid.attach(&kind, 0, 0, 1, 1);
-                add_css_provider!(css_provider, grid, word, kind, info, row, menu);
-                return CompletionItemWidgetWrap {
-                    item,
-                    info,
-                    row,
-                    kind,
-                    menu,
-                };
-            },
-            Err(_) => {
-                add_css_provider!(css_provider, grid, word, info, row, menu);
-                return CompletionItemWidgetWrap {
-                    item,
-                    info,
-                    row,
-                    kind: gtk::Image::new(),
-                    menu,
-                }
-            },
-        };
+        add_css_provider!(css_provider, grid, word, image, info, row, menu);
+
+        let kind = item.kind.clone();
+        CompletionItemWidgetWrap {
+            item,
+            info,
+            row,
+            image,
+            kind,
+            menu,
+        }
     }
 }
 
@@ -108,69 +107,64 @@ fn shorten_info(info: &String) -> String {
 }
 
 pub fn get_icon_pixbuf(
-    kind: &str,
+    kind: &CompletionItemKind,
     color: &Color,
     size: f64,
-    know_items_kinds: bool,
-) -> Result<gdk_pixbuf::Pixbuf, gdk_pixbuf::Error> {
-    let contents = get_icon_name_for_kind(kind,
-                                          &color,
-                                          size,
-                                          know_items_kinds);
+) -> gdk_pixbuf::Pixbuf {
+    let contents = get_icon_name_for_kind(kind, &color, size);
     let stream = gio::MemoryInputStream::new_from_bytes(&glib::Bytes::from(
         contents.as_bytes(),
     ));
-    let buf = gdk_pixbuf::Pixbuf::new_from_stream(&stream, None);
+    let buf = gdk_pixbuf::Pixbuf::new_from_stream(&stream, None).unwrap();
 
     buf
 }
 
-fn get_icon_name_for_kind(kind: &str, color: &Color, size: f64,
-                          know_items_kinds: bool) -> String {
+fn get_icon_name_for_kind(
+    kind: &CompletionItemKind,
+    color: &Color,
+    size: f64,
+) -> String {
     let color = color.to_hex();
 
     let size = size * 1.1;
 
+    use self::CompletionItemKind::*;
     match kind {
-        "method" | "function" | "constructor" => {
-            icon!("../../../assets/icons/box.svg", color, size)
-        }
-        "field" => {
+        Constructor => icon!("../../../assets/icons/box.svg", color, size),
+        Method => icon!("../../../assets/icons/box.svg", color, size),
+        Function => icon!("../../../assets/icons/box.svg", color, size),
+        Field => {
             icon!("../../../assets/icons/chevrons-right.svg", color, size)
         }
-        "event" => icon!("../../../assets/icons/zap.svg", color, size),
-        "operator" => icon!("../../../assets/icons/sliders.svg", color, size),
-        "variable" => icon!("../../../assets/icons/disc.svg", color, size),
-        "class" => icon!("../../../assets/icons/share-2.svg", color, size),
-        "interface" => {
+        Event => icon!("../../../assets/icons/zap.svg", color, size),
+        Operator => icon!("../../../assets/icons/sliders.svg", color, size),
+        Variable => icon!("../../../assets/icons/disc.svg", color, size),
+        Class => icon!("../../../assets/icons/share-2.svg", color, size),
+        Interface => {
             icon!("../../../assets/icons/book-open.svg", color, size)
         }
-        "struct" => icon!("../../../assets/icons/align-left.svg", color, size),
-        "type parameter" => {
+        Struct => icon!("../../../assets/icons/align-left.svg", color, size),
+        TypeParameter => {
             icon!("../../../assets/icons/type.svg", color, size)
         }
-        "module" => icon!("../../../assets/icons/code.svg", color, size),
-        "property" => icon!("../../../assets/icons/key.svg", color, size),
-        "unit" => icon!("../../../assets/icons/compass.svg", color, size),
-        "constant" => icon!("../../../assets/icons/shield.svg", color, size),
-        "value" | "enum" => {
+        Module => icon!("../../../assets/icons/code.svg", color, size),
+        Property => icon!("../../../assets/icons/key.svg", color, size),
+        Unit => icon!("../../../assets/icons/compass.svg", color, size),
+        Constant => icon!("../../../assets/icons/shield.svg", color, size),
+        Value => icon!("../../../assets/icons/database.svg", color, size),
+        Enum => {
             icon!("../../../assets/icons/database.svg", color, size)
         }
-        "enum member" => icon!("../../../assets/icons/tag.svg", color, size),
-        "keyword" => icon!("../../../assets/icons/link-2.svg", color, size),
-        "text" => icon!("../../../assets/icons/at-sign.svg", color, size),
-        "color" => icon!("../../../assets/icons/aperture.svg", color, size),
-        "file" => icon!("../../../assets/icons/file.svg", color, size),
-        "reference" => icon!("../../../assets/icons/link.svg", color, size),
-        "snippet" => icon!("../../../assets/icons/file-text.svg", color, size),
-        "folder" => icon!("../../../assets/icons/folder.svg", color, size),
+        EnumMember => icon!("../../../assets/icons/tag.svg", color, size),
+        Keyword => icon!("../../../assets/icons/link-2.svg", color, size),
+        Text => icon!("../../../assets/icons/at-sign.svg", color, size),
+        Color => icon!("../../../assets/icons/aperture.svg", color, size),
+        File => icon!("../../../assets/icons/file.svg", color, size),
+        Reference => icon!("../../../assets/icons/link.svg", color, size),
+        Snippet => icon!("../../../assets/icons/file-text.svg", color, size),
+        Folder => icon!("../../../assets/icons/folder.svg", color, size),
 
-        _ => {
-            if know_items_kinds {
-                icon!("../../../assets/icons/help-circle.svg", color, size)
-            } else {
-                String::from("")
-            }
-        },
+        _ => icon!("../../../assets/icons/help-circle.svg", color, size),
     }
 }

--- a/src/ui/popupmenu/completion_item_widget.rs
+++ b/src/ui/popupmenu/completion_item_widget.rs
@@ -156,7 +156,6 @@ fn get_icon_name_for_kind(kind: &str, color: &Color, size: f64) -> String {
         "snippet" => icon!("../../../assets/icons/file-text.svg", color, size),
         "folder" => icon!("../../../assets/icons/folder.svg", color, size),
 
-       // _ => icon!("../../../assets/icons/help-circle.svg", color, size),
         _ => String::from("None"),
     }
 }

--- a/src/ui/popupmenu/completion_item_widget.rs
+++ b/src/ui/popupmenu/completion_item_widget.rs
@@ -40,19 +40,11 @@ impl CompletionItemWidgetWrap {
         let grid = gtk::Grid::new();
         grid.set_column_spacing(10);
 
-        let buf = get_icon_pixbuf(&item.kind, icon_fg, size);
-        let image = match &item.kind {
-            CompletionItemKind::Unknown => {
-                // If another item in the popupmenu has a known kind,
-                // give kind_image an icon.
-                if show_kind {
-                    gtk::Image::new_from_pixbuf(&buf)
-                } else {
-                    gtk::Image::new()
-                }
-            }
-            _ => gtk::Image::new_from_pixbuf(&buf),
-        };
+        let image = gtk::Image::new();
+        if show_kind {
+            let buf = get_icon_pixbuf(&item.kind, icon_fg, size);
+            image.set_from_pixbuf(&buf);
+        }
 
         image.set_tooltip_text(format!("kind: '{}'", item.kind_raw).as_str());
         image.set_margin_start(margin);

--- a/src/ui/popupmenu/completion_item_widget.rs
+++ b/src/ui/popupmenu/completion_item_widget.rs
@@ -117,20 +117,6 @@ pub fn get_icon_pixbuf(
     buf
 }
 
-// pub fn get_icon_pixbuf(
-//     kind: &str,
-//     color: &Color,
-//     size: f64,
-// ) -> gdk_pixbuf::Pixbuf {
-//     let contents = get_icon_name_for_kind(kind, &color, size);
-//     let stream = gio::MemoryInputStream::new_from_bytes(&glib::Bytes::from(
-//         contents.as_bytes(),
-//     ));
-//     let buf = gdk_pixbuf::Pixbuf::new_from_stream(&stream, None).unwrap();
-// 
-//     buf
-// }
-
 fn get_icon_name_for_kind(kind: &str, color: &Color, size: f64) -> String {
     let color = color.to_hex();
 

--- a/src/ui/popupmenu/completion_item_widget.rs
+++ b/src/ui/popupmenu/completion_item_widget.rs
@@ -1,7 +1,7 @@
 use gtk;
 use gtk::prelude::*;
 
-use nvim_bridge::{ CompletionItem, CompletionItemKind };
+use nvim_bridge::{CompletionItem, CompletionItemKind};
 use ui::color::Color;
 
 macro_rules! icon {
@@ -30,7 +30,7 @@ pub struct CompletionItemWidgetWrap {
 impl CompletionItemWidgetWrap {
     pub fn create(
         item: CompletionItem,
-        items: &Vec<CompletionItem>,
+        show_kind: bool,
         css_provider: &gtk::CssProvider,
         icon_fg: &Color,
         size: f64,
@@ -45,14 +45,16 @@ impl CompletionItemWidgetWrap {
             CompletionItemKind::Unknown => {
                 // If another item in the popupmenu has a known kind,
                 // give kind_image an icon.
-                if items.iter().any(|item| !item.kind.is_unknown()) {
-                    gtk::Image::new_from_pixbuf(&buf) 
-                } else { gtk::Image::new() }
+                if show_kind {
+                    gtk::Image::new_from_pixbuf(&buf)
+                } else {
+                    gtk::Image::new()
+                }
             }
             _ => gtk::Image::new_from_pixbuf(&buf),
         };
 
-        // kind_image.set_tooltip_text(format!("kind: '{}'", &item.kind.get_kind()).as_str());
+        image.set_tooltip_text(format!("kind: '{}'", item.kind_raw).as_str());
         image.set_margin_start(margin);
         grid.attach(&image, 0, 0, 1, 1);
 
@@ -134,28 +136,20 @@ fn get_icon_name_for_kind(
         Constructor => icon!("../../../assets/icons/box.svg", color, size),
         Method => icon!("../../../assets/icons/box.svg", color, size),
         Function => icon!("../../../assets/icons/box.svg", color, size),
-        Field => {
-            icon!("../../../assets/icons/chevrons-right.svg", color, size)
-        }
+        Field => icon!("../../../assets/icons/chevrons-right.svg", color, size),
         Event => icon!("../../../assets/icons/zap.svg", color, size),
         Operator => icon!("../../../assets/icons/sliders.svg", color, size),
         Variable => icon!("../../../assets/icons/disc.svg", color, size),
         Class => icon!("../../../assets/icons/share-2.svg", color, size),
-        Interface => {
-            icon!("../../../assets/icons/book-open.svg", color, size)
-        }
+        Interface => icon!("../../../assets/icons/book-open.svg", color, size),
         Struct => icon!("../../../assets/icons/align-left.svg", color, size),
-        TypeParameter => {
-            icon!("../../../assets/icons/type.svg", color, size)
-        }
+        TypeParameter => icon!("../../../assets/icons/type.svg", color, size),
         Module => icon!("../../../assets/icons/code.svg", color, size),
         Property => icon!("../../../assets/icons/key.svg", color, size),
         Unit => icon!("../../../assets/icons/compass.svg", color, size),
         Constant => icon!("../../../assets/icons/shield.svg", color, size),
         Value => icon!("../../../assets/icons/database.svg", color, size),
-        Enum => {
-            icon!("../../../assets/icons/database.svg", color, size)
-        }
+        Enum => icon!("../../../assets/icons/database.svg", color, size),
         EnumMember => icon!("../../../assets/icons/tag.svg", color, size),
         Keyword => icon!("../../../assets/icons/link-2.svg", color, size),
         Text => icon!("../../../assets/icons/at-sign.svg", color, size),

--- a/src/ui/popupmenu/completion_item_widget.rs
+++ b/src/ui/popupmenu/completion_item_widget.rs
@@ -44,11 +44,12 @@ impl CompletionItemWidgetWrap {
         if show_kind {
             let buf = get_icon_pixbuf(&item.kind, icon_fg, size);
             image.set_from_pixbuf(&buf);
+            image.set_tooltip_text(
+                format!("kind: '{}'", item.kind_raw).as_str(),
+            );
+            image.set_margin_start(margin);
+            grid.attach(&image, 0, 0, 1, 1);
         }
-
-        image.set_tooltip_text(format!("kind: '{}'", item.kind_raw).as_str());
-        image.set_margin_start(margin);
-        grid.attach(&image, 0, 0, 1, 1);
 
         let menu = gtk::Label::new(item.menu.as_str());
         menu.set_halign(gtk::Align::End);
@@ -59,6 +60,9 @@ impl CompletionItemWidgetWrap {
 
         let word = gtk::Label::new(item.word.as_str());
         word.set_ellipsize(pango::EllipsizeMode::End);
+        if !show_kind {
+            word.set_margin_start(5);
+        }
         grid.attach(&word, 1, 0, 1, 1);
 
         let info = gtk::Label::new(shorten_info(&item.info).as_str());

--- a/src/ui/popupmenu/completion_item_widget.rs
+++ b/src/ui/popupmenu/completion_item_widget.rs
@@ -31,6 +31,7 @@ impl CompletionItemWidgetWrap {
         css_provider: &gtk::CssProvider,
         icon_fg: &Color,
         size: f64,
+        know_items_kinds: bool,
     ) -> Self {
         let margin = (size / 3.0) as i32;
 
@@ -66,7 +67,10 @@ impl CompletionItemWidgetWrap {
         let row = gtk::ListBoxRow::new();
         row.add(&grid);
 
-        let buf = get_icon_pixbuf(&item.kind.as_str(), icon_fg, size);
+        let buf = get_icon_pixbuf(&item.kind.as_str(),
+                                    icon_fg, 
+                                    size,
+                                    know_items_kinds);
         match buf {
             Ok(buff) => {
                 let kind = gtk::Image::new_from_pixbuf(&buff);
@@ -107,8 +111,12 @@ pub fn get_icon_pixbuf(
     kind: &str,
     color: &Color,
     size: f64,
+    know_items_kinds: bool,
 ) -> Result<gdk_pixbuf::Pixbuf, gdk_pixbuf::Error> {
-    let contents = get_icon_name_for_kind(kind, &color, size);
+    let contents = get_icon_name_for_kind(kind,
+                                          &color,
+                                          size,
+                                          know_items_kinds);
     let stream = gio::MemoryInputStream::new_from_bytes(&glib::Bytes::from(
         contents.as_bytes(),
     ));
@@ -117,7 +125,8 @@ pub fn get_icon_pixbuf(
     buf
 }
 
-fn get_icon_name_for_kind(kind: &str, color: &Color, size: f64) -> String {
+fn get_icon_name_for_kind(kind: &str, color: &Color, size: f64,
+                          know_items_kinds: bool) -> String {
     let color = color.to_hex();
 
     let size = size * 1.1;
@@ -156,6 +165,12 @@ fn get_icon_name_for_kind(kind: &str, color: &Color, size: f64) -> String {
         "snippet" => icon!("../../../assets/icons/file-text.svg", color, size),
         "folder" => icon!("../../../assets/icons/folder.svg", color, size),
 
-        _ => String::from("None"),
+        _ => {
+            if know_items_kinds {
+                icon!("../../../assets/icons/help-circle.svg", color, size)
+            } else {
+                String::from("")
+            }
+        },
     }
 }

--- a/src/ui/popupmenu/completion_item_widget.rs
+++ b/src/ui/popupmenu/completion_item_widget.rs
@@ -60,14 +60,16 @@ impl CompletionItemWidgetWrap {
 
         let word = gtk::Label::new(item.word.as_str());
         word.set_ellipsize(pango::EllipsizeMode::End);
-        if !show_kind {
-            word.set_margin_start(5);
-        }
         grid.attach(&word, 1, 0, 1, 1);
 
         let info = gtk::Label::new(shorten_info(&item.info).as_str());
         info.set_halign(gtk::Align::Start);
         info.set_ellipsize(pango::EllipsizeMode::End);
+
+        if !show_kind {
+            word.set_margin_start(5);
+            info.set_margin_start(5);
+        }
 
         info.connect_realize(|info| {
             info.hide();

--- a/src/ui/popupmenu/lazy_loader.rs
+++ b/src/ui/popupmenu/lazy_loader.rs
@@ -67,18 +67,7 @@ impl LazyLoader {
         let mut state = self.state.borrow_mut();
         state.clear();
 
-        state.items_to_load = items;
-
-        // Check if CompletionItems have known kinds
-        let mut know_items_kinds = false;
-        for item in state.items_to_load.iter() {
-            use ui::popupmenu::get_icon_pixbuf;
-            match get_icon_pixbuf(&item.kind, &icon_fg, size, know_items_kinds) {
-                Ok(_) => know_items_kinds = true,
-                Err(_) => continue,
-            }
-        }
-
+        state.items_to_load = items.clone();
 
         let state_ref = self.state.clone();
         let source_id = glib::idle_add(move || {
@@ -100,10 +89,10 @@ impl LazyLoader {
                 let item = state.items_to_load.remove(0);
                 let widget = CompletionItemWidgetWrap::create(
                     item,
+                    &items,
                     &state.css_provider,
                     &icon_fg,
                     size,
-                    know_items_kinds,
                 );
                 state.list.add(&widget.row);
                 widget.row.show_all();

--- a/src/ui/popupmenu/lazy_loader.rs
+++ b/src/ui/popupmenu/lazy_loader.rs
@@ -73,8 +73,8 @@ impl LazyLoader {
         let mut state = self.state.borrow_mut();
         state.clear();
 
-        state.items_to_load = items.clone();
         state.show_kind = items.iter().any(|item| !item.kind.is_unknown());
+        state.items_to_load = items;
 
         let state_ref = self.state.clone();
         let source_id = glib::idle_add(move || {

--- a/src/ui/popupmenu/lazy_loader.rs
+++ b/src/ui/popupmenu/lazy_loader.rs
@@ -69,6 +69,17 @@ impl LazyLoader {
 
         state.items_to_load = items;
 
+        // Check if CompletionItems have known kinds
+        let mut know_items_kinds = false;
+        for item in state.items_to_load.iter() {
+            use ui::popupmenu::get_icon_pixbuf;
+            match get_icon_pixbuf(&item.kind, &icon_fg, size, know_items_kinds) {
+                Ok(_) => know_items_kinds = true,
+                Err(_) => continue,
+            }
+        }
+
+
         let state_ref = self.state.clone();
         let source_id = glib::idle_add(move || {
             let mut state = state_ref.borrow_mut();
@@ -92,6 +103,7 @@ impl LazyLoader {
                     &state.css_provider,
                     &icon_fg,
                     size,
+                    know_items_kinds,
                 );
                 state.list.add(&widget.row);
                 widget.row.show_all();

--- a/src/ui/popupmenu/lazy_loader.rs
+++ b/src/ui/popupmenu/lazy_loader.rs
@@ -12,6 +12,7 @@ use ui::popupmenu::CompletionItemWidgetWrap;
 struct State {
     items: Vec<CompletionItemWidgetWrap>,
     items_to_load: Vec<CompletionItem>,
+    show_kind: bool,
 
     source_id: Option<glib::SourceId>,
 
@@ -43,6 +44,7 @@ impl State {
             source_id: None,
             list,
             css_provider,
+            show_kind: false,
         }
     }
 }
@@ -58,6 +60,10 @@ impl LazyLoader {
         }
     }
 
+    pub fn get_show_kind(&self) -> bool {
+        self.state.borrow().show_kind
+    }
+
     pub fn set_items(
         &mut self,
         items: Vec<CompletionItem>,
@@ -68,6 +74,7 @@ impl LazyLoader {
         state.clear();
 
         state.items_to_load = items.clone();
+        state.show_kind = items.iter().any(|item| !item.kind.is_unknown());
 
         let state_ref = self.state.clone();
         let source_id = glib::idle_add(move || {
@@ -89,7 +96,7 @@ impl LazyLoader {
                 let item = state.items_to_load.remove(0);
                 let widget = CompletionItemWidgetWrap::create(
                     item,
-                    &items,
+                    state.show_kind,
                     &state.css_provider,
                     &icon_fg,
                     size,

--- a/src/ui/popupmenu/popupmenu.rs
+++ b/src/ui/popupmenu/popupmenu.rs
@@ -389,9 +389,10 @@ impl Popupmenu {
                 prev.info.set_visible(false);
                 prev.menu.set_visible(false);
 
-                // Update the `kind` icon with default fg color if it is an icon.
-                let buf = get_icon_pixbuf(&prev.item.kind, &fg, font_height);
                 if show_kind {
+                    // Update the `kind` icon with default fg color.
+                    let buf =
+                        get_icon_pixbuf(&prev.item.kind, &fg, font_height);
                     prev.image.set_from_pixbuf(&buf);
                 }
             }
@@ -445,10 +446,10 @@ impl Popupmenu {
                     *id.borrow_mut() = Some(sig_id);
                 }
 
-                // Update the `kind` icon with "selected" fg color if it is an icon.
-                let buf =
-                    get_icon_pixbuf(&item.item.kind, &fg_sel, font_height);
                 if show_kind {
+                    // Update the `kind` icon with "selected" fg color.
+                    let buf =
+                        get_icon_pixbuf(&item.item.kind, &fg_sel, font_height);
                     item.image.set_from_pixbuf(&buf);
                 }
 

--- a/src/ui/popupmenu/popupmenu.rs
+++ b/src/ui/popupmenu/popupmenu.rs
@@ -384,12 +384,22 @@ impl Popupmenu {
         self.items.once_loaded(Some(item_num), move |items| {
             let mut state = state.borrow_mut();
 
+            // Check if other CompletionItems have kinds with pixbufs
+            let mut know_items_kinds = false;
+            for item in items.iter() {
+                match item.kind.get_pixbuf() {
+                    Some(_) => know_items_kinds = true,
+                    None => continue,
+                }
+            }
+
+
             if let Some(prev) = items.get(state.selected as usize) {
                 prev.info.set_visible(false);
                 prev.menu.set_visible(false);
 
                 // Update the `kind` icon with default fg color if it is an icon.
-                let buf = get_icon_pixbuf(&prev.item.kind, &fg, font_height);
+                let buf = get_icon_pixbuf(&prev.item.kind, &fg, font_height, know_items_kinds);
                 if let Err(_) = buf {} else {
                     prev.kind.set_from_pixbuf(&buf.unwrap());
                 };
@@ -444,8 +454,17 @@ impl Popupmenu {
                     *id.borrow_mut() = Some(sig_id);
                 }
 
+                // Check if other CompletionItems have kinds with pixbufs
+                let mut know_items_kinds = false;
+                for item in items.iter() {
+                    match item.kind.get_pixbuf() {
+                        Some(_) => know_items_kinds = true,
+                        None => continue,
+                    }
+                }
+
                 // Update the `kind` icon with "selected" fg color if it is an icon.
-                let buf = get_icon_pixbuf(&item.item.kind, &fg_sel, font_height);
+                let buf = get_icon_pixbuf(&item.item.kind, &fg_sel, font_height, know_items_kinds);
                 if let Err(_) = buf {} else {
                     item.kind.set_from_pixbuf(&buf.unwrap());
                 };

--- a/src/ui/popupmenu/popupmenu.rs
+++ b/src/ui/popupmenu/popupmenu.rs
@@ -388,9 +388,11 @@ impl Popupmenu {
                 prev.info.set_visible(false);
                 prev.menu.set_visible(false);
 
-                // Update the `kind` icon with default fg color.
+                // Update the `kind` icon with default fg color if it is an icon.
                 let buf = get_icon_pixbuf(&prev.item.kind, &fg, font_height);
-                prev.kind.set_from_pixbuf(&buf);
+                if let Err(_) = buf {} else {
+                    prev.kind.set_from_pixbuf(&buf.unwrap());
+                };
             }
 
             state.selected = item_num;
@@ -442,10 +444,12 @@ impl Popupmenu {
                     *id.borrow_mut() = Some(sig_id);
                 }
 
-                // Update the `kind` icon with "selected" fg color.
-                let buf =
-                    get_icon_pixbuf(&item.item.kind, &fg_sel, font_height);
-                item.kind.set_from_pixbuf(&buf);
+                // Update the `kind` icon with "selected" fg color if it is an icon.
+                let buf = get_icon_pixbuf(&item.item.kind, &fg_sel, font_height);
+                if let Err(_) = buf {} else {
+                    item.kind.set_from_pixbuf(&buf.unwrap());
+                };
+                
                 let newline =
                     if item.item.menu.len() > 0 && item.item.info.len() > 0 {
                         "\n"

--- a/src/ui/popupmenu/popupmenu.rs
+++ b/src/ui/popupmenu/popupmenu.rs
@@ -380,6 +380,7 @@ impl Popupmenu {
         let list = self.list.clone();
         let info_label = self.info_label.clone();
         let info_shown = self.info_shown;
+        let show_kind = self.items.get_show_kind();
 
         self.items.once_loaded(Some(item_num), move |items| {
             let mut state = state.borrow_mut();
@@ -390,7 +391,7 @@ impl Popupmenu {
 
                 // Update the `kind` icon with default fg color if it is an icon.
                 let buf = get_icon_pixbuf(&prev.item.kind, &fg, font_height);
-                if items.iter().any(|item| !item.kind.is_unknown())  {
+                if show_kind {
                     prev.image.set_from_pixbuf(&buf);
                 }
             }
@@ -445,11 +446,12 @@ impl Popupmenu {
                 }
 
                 // Update the `kind` icon with "selected" fg color if it is an icon.
-                let buf = get_icon_pixbuf(&item.item.kind, &fg_sel, font_height);
-                if items.iter().any(|item| !item.kind.is_unknown()) {
+                let buf =
+                    get_icon_pixbuf(&item.item.kind, &fg_sel, font_height);
+                if show_kind {
                     item.image.set_from_pixbuf(&buf);
                 }
-                
+
                 let newline =
                     if item.item.menu.len() > 0 && item.item.info.len() > 0 {
                         "\n"

--- a/src/ui/popupmenu/popupmenu.rs
+++ b/src/ui/popupmenu/popupmenu.rs
@@ -384,25 +384,15 @@ impl Popupmenu {
         self.items.once_loaded(Some(item_num), move |items| {
             let mut state = state.borrow_mut();
 
-            // Check if other CompletionItems have kinds with pixbufs
-            let mut know_items_kinds = false;
-            for item in items.iter() {
-                match item.kind.get_pixbuf() {
-                    Some(_) => know_items_kinds = true,
-                    None => continue,
-                }
-            }
-
-
             if let Some(prev) = items.get(state.selected as usize) {
                 prev.info.set_visible(false);
                 prev.menu.set_visible(false);
 
                 // Update the `kind` icon with default fg color if it is an icon.
-                let buf = get_icon_pixbuf(&prev.item.kind, &fg, font_height, know_items_kinds);
-                if let Err(_) = buf {} else {
-                    prev.kind.set_from_pixbuf(&buf.unwrap());
-                };
+                let buf = get_icon_pixbuf(&prev.item.kind, &fg, font_height);
+                if items.iter().any(|item| !item.kind.is_unknown())  {
+                    prev.image.set_from_pixbuf(&buf);
+                }
             }
 
             state.selected = item_num;
@@ -454,20 +444,11 @@ impl Popupmenu {
                     *id.borrow_mut() = Some(sig_id);
                 }
 
-                // Check if other CompletionItems have kinds with pixbufs
-                let mut know_items_kinds = false;
-                for item in items.iter() {
-                    match item.kind.get_pixbuf() {
-                        Some(_) => know_items_kinds = true,
-                        None => continue,
-                    }
-                }
-
                 // Update the `kind` icon with "selected" fg color if it is an icon.
-                let buf = get_icon_pixbuf(&item.item.kind, &fg_sel, font_height, know_items_kinds);
-                if let Err(_) = buf {} else {
-                    item.kind.set_from_pixbuf(&buf.unwrap());
-                };
+                let buf = get_icon_pixbuf(&item.item.kind, &fg_sel, font_height);
+                if items.iter().any(|item| !item.kind.is_unknown()) {
+                    item.image.set_from_pixbuf(&buf);
+                }
                 
                 let newline =
                     if item.item.menu.len() > 0 && item.item.info.len() > 0 {


### PR DESCRIPTION
This is an idea of how to remove the 'help-circle.svg' icon from autocompletions that are unknown to clean up the look for completions with unsupported or unimplemented kinds (like those of [LanguageClient-Neovim](https://github.com/autozimu/LanguageClient-neovim)):

![image](https://user-images.githubusercontent.com/46855713/58918488-0f641100-86f0-11e9-93e1-d44ac8cefe03.png)

Any feedback would be much appreciated! Currently this works by filling in an empty image in the popupmenu if there is an error with the icon's `gdk_pixbuf` (which is created from returning the "None" string in the `get_icon_name_for_kind` function).

See #47.
