### PR TITLE
Add Visual Indication to Identify Modified Files in Tabline

### DIFF
--- a/src/ui/tabline.rs
+++ b/src/ui/tabline.rs
@@ -86,17 +86,23 @@ impl Tabline {
 
         let mut page = 0;
         for (i, tab) in tabs.iter().enumerate() {
-            // Check if tab's buffer is modified, if so provide visual indicator
             let mut tab_label;
-            let modified: bool = tab.0
-                .get_win(&mut nvim)
-                .unwrap()
-                .get_buf(&mut nvim)
-                .unwrap()
-                .get_option(&mut nvim, "mod")
-                .unwrap()
-                .as_bool()
-                .unwrap();
+            let modified;
+            match tab.0.get_win(&mut nvim) {
+                Ok(win) => {
+                    modified = win.get_buf(&mut nvim)
+                                      .unwrap()
+                                      .get_option(&mut nvim, "mod")
+                                      .unwrap()
+                                      .as_bool()
+                                      .unwrap();
+                },
+                Err(_) => {
+                    modified = false;
+                },
+            }
+
+            // Provide visual indicator if tab buffer is modified
             if modified {
                 let mut tab_string = String::from(tab.1.as_str());
                 tab_string.push_str(" +");

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -714,7 +714,8 @@ fn handle_redraw_event(
                 state.popupmenu.select(*selected as i32, &state.hl_defs);
             }
             RedrawEvent::TablineUpdate(cur, tabs) => {
-                state.tabline.update(nvim.clone(), cur.clone(), tabs.clone());
+                let mut nvim = nvim.lock().unwrap();
+                state.tabline.update(&mut nvim, cur.clone(), tabs.clone());
             }
             RedrawEvent::CmdlineShow(cmdline_show) => {
                 state.cmdline.show(cmdline_show, &state.hl_defs);

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -714,7 +714,7 @@ fn handle_redraw_event(
                 state.popupmenu.select(*selected as i32, &state.hl_defs);
             }
             RedrawEvent::TablineUpdate(cur, tabs) => {
-                state.tabline.update(cur.clone(), tabs.clone());
+                state.tabline.update(nvim.clone(), cur.clone(), tabs.clone());
             }
             RedrawEvent::CmdlineShow(cmdline_show) => {
                 state.cmdline.show(cmdline_show, &state.hl_defs);


### PR DESCRIPTION
This PR makes gnvim show the `+` symbol for a modified file in the tabline:
![image](https://user-images.githubusercontent.com/46855713/59164490-0483f480-8ad3-11e9-8928-e19f85052ad5.png)
See #51.

I implemented this based off of vhakulinen's info in #51, but feedback/suggestions are much appreciated.