### PR TITLE
[WIP] Add externalized messages support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
  "glib 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gtk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "neovim-lib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neovim-lib 0.6.0 (git+https://github.com/badosu/neovim-lib?branch=badosu/add-ext-messages)",
  "pango 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pangocairo 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -531,10 +531,9 @@ dependencies = [
 [[package]]
 name = "neovim-lib"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/badosu/neovim-lib?branch=badosu/add-ext-messages#26343f64f2cb423cdd06da6f5df8a1f5dc9252fb"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1281,7 +1280,7 @@ dependencies = [
 "checksum miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649"
 "checksum miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ad30a47319c16cde58d0314f5d98202a80c9083b5f61178457403dfb14e509c"
 "checksum miniz_oxide_c_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28edaef377517fd9fe3e085c37d892ce7acd1fbeab9239c5a36eec352d8a8b7e"
-"checksum neovim-lib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a6df2e6e846e5dbd098b73ba1a39d1f2ff654bb7cc33521fc569aa0da54daaa"
+"checksum neovim-lib 0.6.0 (git+https://github.com/badosu/neovim-lib?branch=badosu/add-ext-messages)" = "<none>"
 "checksum new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cdc457076c78ab54d5e0d6fa7c47981757f1e34dc39ff92787f217dede586c4"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ debug = true
 unstable = []
 
 [dependencies]
-neovim-lib = "0.6"
+neovim-lib = { git = "https://github.com/badosu/neovim-lib", branch = "badosu/add-ext-messages" }
 structopt = "0.2"
 
 gio = "0.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,7 @@ fn build(app: &gtk::Application, opts: &Options) {
     ui_opts.set_cmdline_external(!opts.disable_ext_cmdline);
 
     ui_opts.set_wildmenu_external(true);
+    ui_opts.set_messages_external(true);
     nvim.ui_attach(80, 30, &ui_opts)
         .expect("Failed to attach UI");
 

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -746,6 +746,30 @@ fn handle_redraw_event(
             RedrawEvent::WildmenuSelect(item) => {
                 state.cmdline.wildmenu_select(*item);
             }
+            RedrawEvent::MessageShow(message_entry, replace_last) => {
+                dbg!("MessageShow");
+                dbg!(message_entry);
+                dbg!(replace_last);
+            }
+            RedrawEvent::MessageShowMode(content) => {
+                dbg!("MessageShowMode");
+                dbg!(content);
+            }
+            RedrawEvent::MessageShowCmd(content) => {
+                dbg!("MessageShowCmd");
+                dbg!(content);
+            }
+            RedrawEvent::MessageRuler(content) => {
+                dbg!("MessageRuler");
+                dbg!(content);
+            }
+            RedrawEvent::MessageClear() => {
+                dbg!("MessageClear");
+            }
+            RedrawEvent::MessageHistoryShow(entries) => {
+                dbg!("MessageHistoryShow");
+                dbg!(entries);
+            }
             RedrawEvent::Ignored(_) => (),
             RedrawEvent::Unknown(e) => {
                 println!("Received unknown redraw event: {}", e);


### PR DESCRIPTION
This is the base effort to start support for externalized messages.

My initial motivation was just to show regular messages (`"show_msg"` events), it seems that enabling this externalized setting changes drastically the UI though, passing all responsibility for anything resembling a message to it.

There are 4 kinds of separate UI components that are contemplated by ext_messages:

- Regular messages, these are sent by msg_show, cleared by msg_clear and shown in aggregate by msg_history_show. They span from messages outputted by plugins and vim to confirm dialogs, error messages, etc..
- Mode messages, these are shown when you are outside normal mode on the bottom of the editor when not externalized, "-- INSERT --", "-- VISUAL --", "-- VISUAL LINE --". Emmited by msg_showmode with content, cleared by same event without content.
- Cmd messages, the ones that show the current movement/command chord before conclusion, e.g. 'gg', 'ciw', etc... Emmited by msg_showcmd with content, cleared by same event without content.
- Ruler messages, current line and column being visualized, see :ruler. Emmited by msg_ruler with content, cleared by same event without content.

I would prefer an initial approach just externalizing regular messages and keeping everything else intact, will keep looking to see if that's possible.

Currently it only has the scaffold to deal with message events, it's a spike to see how that would work.

Using local neovim-lib until support for messages lands (https://github.com/daa84/neovim-lib/issues/32).

See: https://github.com/neovim/neovim/blob/master/runtime/doc/ui.txt#L680
A sample of events received: https://gist.github.com/badosu/80e3fe6adc232035cff8e99f3e798199