### PR TITLE
Improve configurability with new rpc messages

### DIFF
--- a/runtime/autoload/gnvim/cmdline.vim
+++ b/runtime/autoload/gnvim/cmdline.vim
@@ -1,0 +1,4 @@
+function! gnvim#cmdline#enable(bool)
+    call rpcnotify(g:gnvim_channel_id, 'Gnvim', 'EnableExtCmdline', a:bool)
+    return ''
+endfunction

--- a/runtime/autoload/gnvim/popupmenu.vim
+++ b/runtime/autoload/gnvim/popupmenu.vim
@@ -10,3 +10,8 @@ function! gnvim#popupmenu#toggle_details()
     call rpcnotify(g:gnvim_channel_id, 'Gnvim', 'CompletionMenuToggleInfo')
     return ''
 endfunction
+
+function! gnvim#popupmenu#enable(bool)
+    call rpcnotify(g:gnvim_channel_id, 'Gnvim', 'EnableExtPmenu', a:bool)
+    return ''
+endfunction

--- a/runtime/autoload/gnvim/tabline.vim
+++ b/runtime/autoload/gnvim/tabline.vim
@@ -1,0 +1,4 @@
+function! gnvim#tabline#enable(bool)
+    call rpcnotify(g:gnvim_channel_id, 'Gnvim', 'EnableExtTabline', a:bool)
+    return ''
+endfunction

--- a/src/nvim_bridge/mod.rs
+++ b/src/nvim_bridge/mod.rs
@@ -818,6 +818,10 @@ impl fmt::Display for RedrawEvent {
 #[derive(Debug, PartialEq)]
 pub enum GnvimEvent {
     SetGuiColors(SetGuiColors),
+    EnableExtTabline(bool),
+    EnableExtCmdline(bool),
+    EnableExtPmenu(bool),
+
     CompletionMenuToggleInfo,
 
     CursorTooltipLoadStyle(String),
@@ -1071,6 +1075,42 @@ pub(crate) fn parse_gnvim_event(
 ) -> Result<GnvimEvent, String> {
     let cmd = try_str!(args.get(0).ok_or("No command given")?, "cmd");
     let res = match cmd {
+        "EnableExtCmdline" => {
+            let option = try_str!(
+                args.get(1).ok_or("No input for EnableExtCmdline")?,
+                "enable ext cmdline"
+            )
+            .parse();
+            if let Err(error) = option {
+                return Err(format!("Didn't receive a boolean: {}", error));
+            }
+
+            GnvimEvent::EnableExtCmdline(option.unwrap())
+        }
+        "EnableExtTabline" => {
+            let option = try_str!(
+                args.get(1).ok_or("No input for EnableExtTabline")?,
+                "enable ext tabline"
+            )
+            .parse();
+            if let Err(error) = option {
+                return Err(format!("Didn't receive a boolean: {}", error));
+            }
+
+            GnvimEvent::EnableExtTabline(option.unwrap())
+        }
+        "EnableExtPmenu" => {
+            let option = try_str!(
+                args.get(1).ok_or("No input for EnableExtPmenu")?,
+                "enable ext pmenu"
+            )
+            .parse();
+            if let Err(error) = option {
+                return Err(format!("Didn't receive a boolean: {}", error));
+            }
+
+            GnvimEvent::EnableExtPmenu(option.unwrap())
+        }
         "SetGuiColors" => {
             let mut colors = SetGuiColors::default();
 

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -446,6 +446,35 @@ fn handle_gnvim_event(
                         err
                     ));
                 });
+
+            if !*option {
+                state.tabline.get_widget().hide();
+                return;
+            }
+
+            match (nvim.get_current_tabpage(), nvim.list_tabpages()) {
+                (Ok(current), Ok(tabpages)) => {
+                    let tabpages = tabpages
+                        .iter()
+                        .map(|x| (x.clone(), String::from("")))
+                        .collect();
+
+                    state.tabline.update(&mut nvim, current, tabpages);
+                }
+                (Err(err), Ok(_)) => {
+                    nvim.command_async(&format!(
+                            "echo \"Unable to get current tabpage for updating tabline: '{}'\"", err));
+                }
+                (Ok(_), Err(err)) => {
+                    nvim.command_async(&format!(
+                            "echo \"Unable to get tabpages for updating tabline: '{}'\"", err));
+                }
+                (Err(get_current_err), Err(list_tabpages_err)) => {
+                    nvim.command_async(&format!(
+                            "echo \"Unable to get current tabpage for updating tabline: '{}'\n
+                            Unable to get tabpages for updating tabline: '{}'\"", get_current_err, list_tabpages_err));
+                }
+            }
         }
         GnvimEvent::EnableExtPmenu(option) => {
             let mut nvim = nvim.lock().unwrap();

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -409,7 +409,7 @@ fn handle_gnvim_event(
 ) {
     match event {
         GnvimEvent::EnableExtTabline(option) => {
-            let mut nvim = nvim.lock().unwrap();
+            let mut nvim = nvim.borrow_mut();
             nvim.set_option(UiOption::ExtTabline(*option))
                 .unwrap_or_else(|err| {
                     nvim.command_async(&format!(
@@ -448,7 +448,7 @@ fn handle_gnvim_event(
             }
         }
         GnvimEvent::EnableExtPmenu(option) => {
-            let mut nvim = nvim.lock().unwrap();
+            let mut nvim = nvim.borrow_mut();
             nvim.set_option(UiOption::ExtPopupmenu(*option))
                 .unwrap_or_else(|err| {
                     nvim.command_async(&format!(
@@ -458,7 +458,7 @@ fn handle_gnvim_event(
                 });
         }
         GnvimEvent::EnableExtCmdline(option) => {
-            let mut nvim = nvim.lock().unwrap();
+            let mut nvim = nvim.borrow_mut();
             nvim.set_option(UiOption::ExtCmdline(*option))
                 .unwrap_or_else(|err| {
                     nvim.command_async(&format!(

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -7,7 +7,7 @@ use std::time;
 use gdk;
 use glib;
 use gtk;
-use neovim_lib::neovim::Neovim;
+use neovim_lib::neovim::{Neovim, UiOption};
 use neovim_lib::neovim_api::NeovimApi;
 use neovim_lib::NeovimApiAsync;
 use neovim_lib::Value;
@@ -437,6 +437,37 @@ fn handle_gnvim_event(
     nvim: Arc<Mutex<Neovim>>,
 ) {
     match event {
+        GnvimEvent::EnableExtTabline(option) => {
+            let mut nvim = nvim.lock().unwrap();
+            nvim.set_option(UiOption::ExtTabline(*option))
+                .unwrap_or_else(|err| {
+                    nvim.command_async(&format!(
+                        "echo \"Failed to enable ext_tabline: '{}'\"",
+                        err
+                    ));
+                });
+        }
+        GnvimEvent::EnableExtPmenu(option) => {
+            let mut nvim = nvim.lock().unwrap();
+            nvim.set_option(UiOption::ExtPopupmenu(*option))
+                .unwrap_or_else(|err| {
+                    nvim.command_async(&format!(
+                        "echo \"Failed to enable ext_popupmenu: '{}'\"",
+                        err
+                    ));
+                });
+        }
+        GnvimEvent::EnableExtCmdline(option) => {
+            let mut nvim = nvim.lock().unwrap();
+            nvim.set_option(UiOption::ExtCmdline(*option))
+                .unwrap_or_else(|err| {
+                    nvim.command_async(&format!(
+                        "echo \"Failed to enable ext_cmdline: '{}'\"",
+                        err
+                    ));
+                });
+        }
+
         GnvimEvent::SetGuiColors(colors) => {
             state.popupmenu.set_colors(colors.pmenu, &state.hl_defs);
             state.tabline.set_colors(colors.tabline, &state.hl_defs);


### PR DESCRIPTION
This mostly works, with only one current problem: when the user disables the ext_tabline while it is in use, it doesn't disappear (and couldn't be made to go away through closing tabs when I tested), so that he ends up with something like this (gnvim's tabs won't go away):

![image](https://user-images.githubusercontent.com/46855713/60534609-d788c300-9cc7-11e9-9d72-2955e642a63d.png)

Also, after disabling the ext_tabline the TUI tabline doesn't appear until the user changes tabs (at least when I tested it). I can work on fixing this once we know how we want to go about doing so (I don't want to bloat the code base with a bad solution). (As an FYI I am using Neovim master from about a week ago, give or take.) I don't think this could be a problem with the popupmenu, since one can't call the commands to enable/disable it without exiting insert mode (may be wrong though).

If we want to add any other configuration options, let me know and I'll add them. Any feedback is much appreciated. (Note that once things are solidified here, we’ll probably want to add documentation for the new commands. Don’t want to do that just yet though, since we may want to change the command names, add more commands, etc.)

See #59.