### PR TITLE
[WIP] Only print debug messages when compiled in debug mode

### DIFF
--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -421,7 +421,8 @@ fn handle_notify(
                 ))
                 .cb(|res| match res {
                     Ok(_) => {}
-                    Err(err) => {
+                    Err(err) =>
+                    {
                         #[cfg(debug_assertions)]
                         println!("Failed to execute nvim command: {}", err)
                     }
@@ -458,7 +459,8 @@ fn handle_gnvim_event(
                 ))
                 .cb(|res| match res {
                     Ok(_) => {}
-                    Err(err) => {
+                    Err(err) =>
+                    {
                         #[cfg(debug_assertions)]
                         println!("Failed to execute nvim command: {}", err)
                     }

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -147,6 +147,7 @@ impl UI {
                 nvim.ui_try_resize_async(cols as i64, rows as i64)
                     .cb(|res| {
                         if let Err(err) = res {
+                            #[cfg(debug_assertions)]
                             eprintln!("Error: failed to resize nvim when grid size changed ({:?})", err);
                         }
                     })
@@ -239,6 +240,7 @@ impl UI {
                     nvim.input(input.as_str()).expect("Couldn't send input");
                     return Inhibit(true);
                 } else {
+                    #[cfg(debug_assertions)]
                     println!(
                         "Failed to turn input event into nvim key (keyval: {})",
                         e.get_keyval()
@@ -420,6 +422,7 @@ fn handle_notify(
                 .cb(|res| match res {
                     Ok(_) => {}
                     Err(err) => {
+                        #[cfg(debug_assertions)]
                         println!("Failed to execute nvim command: {}", err)
                     }
                 })
@@ -456,6 +459,7 @@ fn handle_gnvim_event(
                 .cb(|res| match res {
                     Ok(_) => {}
                     Err(err) => {
+                        #[cfg(debug_assertions)]
                         println!("Failed to execute nvim command: {}", err)
                     }
                 })
@@ -484,6 +488,7 @@ fn handle_gnvim_event(
             state.popupmenu.set_width_details(*width as i32);
         }
         GnvimEvent::Unknown(msg) => {
+            #[cfg(debug_assertions)]
             println!("Received unknown GnvimEvent: {}", msg);
         }
     }
@@ -548,7 +553,10 @@ fn handle_redraw_event(
                 nvim.command_async("if exists('#User#GnvimScroll') | doautocmd User GnvimScroll | endif")
                     .cb(|res| match res {
                         Ok(_) => {}
-                        Err(err) => println!("GnvimScroll error: {:?}", err),
+                        Err(err) => {
+                            #[cfg(debug_assertions)]
+                            println!("GnvimScroll error: {:?}", err);
+                        }
                     })
                     .call();
             }
@@ -603,6 +611,7 @@ fn handle_redraw_event(
                             nvim.ui_try_resize_async(cols as i64, rows as i64)
                                 .cb(|res| {
                                     if let Err(err) = res {
+                                        #[cfg(debug_assertions)]
                                         eprintln!("Error: failed to resize nvim on font change ({:?})", err);
                                     }
                                 })
@@ -633,6 +642,7 @@ fn handle_redraw_event(
                             nvim.ui_try_resize_async(cols as i64, rows as i64)
                                 .cb(|res| {
                                     if let Err(err) = res {
+                                        #[cfg(debug_assertions)]
                                         eprintln!("Error: failed to resize nvim on line space change ({:?})", err);
                                     }
                                 })
@@ -645,6 +655,7 @@ fn handle_redraw_event(
                             state.tabline.set_line_space(*val, &state.hl_defs);
                         }
                         OptionSet::NotSupported(name) => {
+                            #[cfg(debug_assertions)]
                             println!("Not supported option set: {}", name);
                         }
                     }
@@ -749,6 +760,7 @@ fn handle_redraw_event(
             }
             RedrawEvent::Ignored(_) => (),
             RedrawEvent::Unknown(e) => {
+                #[cfg(debug_assertions)]
                 println!("Received unknown redraw event: {}", e);
             }
         }


### PR DESCRIPTION
This is an idea of how we could make GNvim print debug statements only when compiled with `cargo run` (i.e. in debug mode). It isn't ready for merging yet, as it needs more `#[cfg(debug_assertions)]` statements and needs to silence the generated warnings (`variable_unused` warnings due to the code not always being there. A simple workaround would be to prefix the variables with underscores). That’s assuming we want to do this, and do it in this way.

The reason for this comes from users’ seeing the error/println messages when running gnvim in release mode (i.e. when it is installed).

This could make the code base less readable, so I am not sure if we want this. But I figured I'd throw it out there anyways, just to show it is an option. (Of course we could just remove the debug `println!` statements, but this is a way we can keep them in the code.) Other approaches are probably possible, and if we continue forward we may want to look into them.

Any feedback is much appreciated.

See:
https://doc.rust-lang.org/beta/reference/conditional-compilation.html
https://users.rust-lang.org/t/conditional-compilation-for-debug-release/1098/8
`debug_assertions`: https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections
debug/release conditional compilation may also be improved in the future: https://github.com/rust-lang/rust/issues/59999