### PR TITLE
Fix `RedrawEvent::GridScroll`

### DIFF
--- a/src/nvim_bridge/mod.rs
+++ b/src/nvim_bridge/mod.rs
@@ -327,6 +327,10 @@ pub struct CmdlineShow {
 }
 
 #[derive(Debug, PartialEq)]
+/// grid, [top, bot, left, right], rows, cols
+pub struct GridScrollInfo(pub u64, pub [u64; 4], pub i64, pub i64);
+
+#[derive(Debug, PartialEq)]
 pub enum RedrawEvent {
     SetTitle(String),
 
@@ -337,8 +341,7 @@ pub enum RedrawEvent {
     GridCursorGoto(u64, u64, u64),
     /// grid
     GridClear(u64),
-    /// grid, [top, bot, left, right], rows, cols
-    GridScroll(u64, [u64; 4], i64, i64),
+    GridScroll(Vec<GridScrollInfo>),
 
     /// fg, bg, sp
     DefaultColorsSet(Color, Color, Color),
@@ -668,22 +671,28 @@ pub(crate) fn parse_redraw_event(args: Vec<Value>) -> Vec<RedrawEvent> {
                     RedrawEvent::GridClear(id)
                 }
                 "grid_scroll" => {
-                    let args = unwrap_array!(args[1]);
+                    let mut scroll_vec = vec![];
 
-                    let id = unwrap_u64!(args[0]);
-                    let top = unwrap_u64!(args[1]);
-                    let bot = unwrap_u64!(args[2]);
-                    let left = unwrap_u64!(args[3]);
-                    let right = unwrap_u64!(args[4]);
-                    let rows = unwrap_i64!(args[5]);
-                    let cols = unwrap_i64!(args[6]);
+                    for args in unwrap_array!(args)[1..].into_iter() {
+                        let args = unwrap_array!(args);
 
-                    RedrawEvent::GridScroll(
-                        id,
-                        [top, bot, left, right],
-                        rows,
-                        cols,
-                    )
+                        let id = unwrap_u64!(args[0]);
+                        let top = unwrap_u64!(args[1]);
+                        let bot = unwrap_u64!(args[2]);
+                        let left = unwrap_u64!(args[3]);
+                        let right = unwrap_u64!(args[4]);
+                        let rows = unwrap_i64!(args[5]);
+                        let cols = unwrap_i64!(args[6]);
+
+                        scroll_vec.push(GridScrollInfo(
+                            id,
+                            [top, bot, left, right],
+                            rows,
+                            cols,
+                        ));
+                    }
+
+                    RedrawEvent::GridScroll(scroll_vec)
                 }
                 "default_colors_set" => {
                     let args = unwrap_array!(args[1]);

--- a/src/nvim_bridge/mod.rs
+++ b/src/nvim_bridge/mod.rs
@@ -327,8 +327,12 @@ pub struct CmdlineShow {
 }
 
 #[derive(Debug, PartialEq)]
-/// grid, [top, bot, left, right], rows, cols
-pub struct GridScrollInfo(pub u64, pub [u64; 4], pub i64, pub i64);
+pub struct GridScroll {
+    pub grid: u64,
+    pub reg: [u64; 4],
+    pub rows: i64,
+    pub cols: i64,
+}
 
 #[derive(Debug, PartialEq)]
 pub enum RedrawEvent {
@@ -341,7 +345,7 @@ pub enum RedrawEvent {
     GridCursorGoto(u64, u64, u64),
     /// grid
     GridClear(u64),
-    GridScroll(Vec<GridScrollInfo>),
+    GridScroll(Vec<GridScroll>),
 
     /// fg, bg, sp
     DefaultColorsSet(Color, Color, Color),
@@ -684,12 +688,12 @@ pub(crate) fn parse_redraw_event(args: Vec<Value>) -> Vec<RedrawEvent> {
                         let rows = unwrap_i64!(args[5]);
                         let cols = unwrap_i64!(args[6]);
 
-                        scroll_vec.push(GridScrollInfo(
-                            id,
-                            [top, bot, left, right],
+                        scroll_vec.push(GridScroll {
+                            grid: id,
+                            reg: [top, bot, left, right],
                             rows,
                             cols,
-                        ));
+                        });
                     }
 
                     RedrawEvent::GridScroll(scroll_vec)

--- a/src/nvim_bridge/tests.rs
+++ b/src/nvim_bridge/tests.rs
@@ -19,7 +19,7 @@ mod parse_redraw_event_tests {
     use nvim_bridge;
     use nvim_bridge::{
         Cell, CmdlineShow, CompletionItem, CompletionItemKind, CursorShape,
-        GridLineSegment, GridScrollInfo, ModeInfo, OptionSet, PopupmenuShow,
+        GridLineSegment, GridScroll, ModeInfo, OptionSet, PopupmenuShow,
         RedrawEvent,
     };
     use ui::color::{Color, Highlight};
@@ -156,12 +156,12 @@ mod parse_redraw_event_tests {
 
     #[test]
     fn grid_scroll() {
-        let expected = vec![RedrawEvent::GridScroll(vec![GridScrollInfo(
-            1,
-            [132, 321, 2, 51],
-            12,
-            32,
-        )])];
+        let expected = vec![RedrawEvent::GridScroll(vec![GridScroll {
+            grid: 1,
+            reg: [132, 321, 2, 51],
+            rows: 12,
+            cols: 32,
+        }])];
 
         let res = nvim_bridge::parse_redraw_event(args!(
             "grid_scroll".into(),

--- a/src/nvim_bridge/tests.rs
+++ b/src/nvim_bridge/tests.rs
@@ -19,7 +19,8 @@ mod parse_redraw_event_tests {
     use nvim_bridge;
     use nvim_bridge::{
         Cell, CmdlineShow, CompletionItem, CompletionItemKind, CursorShape,
-        GridLineSegment, ModeInfo, OptionSet, PopupmenuShow, RedrawEvent,
+        GridLineSegment, GridScrollInfo, ModeInfo, OptionSet, PopupmenuShow,
+        RedrawEvent,
     };
     use ui::color::{Color, Highlight};
 
@@ -155,8 +156,12 @@ mod parse_redraw_event_tests {
 
     #[test]
     fn grid_scroll() {
-        let expected =
-            vec![RedrawEvent::GridScroll(1, [132, 321, 2, 51], 12, 32)];
+        let expected = vec![RedrawEvent::GridScroll(vec![GridScrollInfo(
+            1,
+            [132, 321, 2, 51],
+            12,
+            32,
+        )])];
 
         let res = nvim_bridge::parse_redraw_event(args!(
             "grid_scroll".into(),

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -538,10 +538,10 @@ fn handle_redraw_event(
                 let grid = state.grids.get(grid).unwrap();
                 grid.clear(&state.hl_defs);
             }
-            RedrawEvent::GridScroll(scroll_vec) => {
-                for info in scroll_vec {
-                    let grid = state.grids.get(&info.0).unwrap();
-                    grid.scroll(info.1, info.2, info.3, &state.hl_defs);
+            RedrawEvent::GridScroll(scroll) => {
+                for info in scroll {
+                    let grid = state.grids.get(&info.grid).unwrap();
+                    grid.scroll(info.reg, info.rows, info.cols, &state.hl_defs);
 
                     let mut nvim = nvim.lock().unwrap();
                     // Since nvim doesn't have its own 'scroll' autocmd, we'll

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -538,19 +538,21 @@ fn handle_redraw_event(
                 let grid = state.grids.get(grid).unwrap();
                 grid.clear(&state.hl_defs);
             }
-            RedrawEvent::GridScroll(grid, reg, rows, cols) => {
-                let grid = state.grids.get(grid).unwrap();
-                grid.scroll(*reg, *rows, *cols, &state.hl_defs);
+            RedrawEvent::GridScroll(scroll_vec) => {
+                for info in scroll_vec {
+                    let grid = state.grids.get(&info.0).unwrap();
+                    grid.scroll(info.1, info.2, info.3, &state.hl_defs);
 
-                let mut nvim = nvim.lock().unwrap();
-                // Since nvim doesn't have its own 'scroll' autocmd, we'll
-                // have to do it on our own. This use useful for the cursor tooltip.
-                nvim.command_async("if exists('#User#GnvimScroll') | doautocmd User GnvimScroll | endif")
-                    .cb(|res| match res {
-                        Ok(_) => {}
-                        Err(err) => println!("GnvimScroll error: {:?}", err),
-                    })
-                    .call();
+                    let mut nvim = nvim.lock().unwrap();
+                    // Since nvim doesn't have its own 'scroll' autocmd, we'll
+                    // have to do it on our own. This use useful for the cursor tooltip.
+                    nvim.command_async("if exists('#User#GnvimScroll') | doautocmd User GnvimScroll | endif")
+                     .cb(|res| match res {
+                         Ok(_) => {}
+                         Err(err) => println!("GnvimScroll error: {:?}", err),
+                     })
+                     .call();
+                }
             }
             RedrawEvent::DefaultColorsSet(fg, bg, sp) => {
                 state.hl_defs.default_fg = *fg;


### PR DESCRIPTION
Fixes #63 (from my tests).

This PR comes from discussion on [GNvim's gitter](https://gitter.im/gnvim/community) about grid scrolling, where it was mentioned that when given a `grid_scroll` event like the following GNvim should execute each event in order: 
`["grid_scroll", [1, 0, 29, 0, 116, 5, 0], [1, 10, 29, 0, 116, -5, 0]]`

Previously, GNvim would only execute the first event, which caused #63. Now that should be fixed.

Let me know if this is how we want to solve this problem. This solution loops through each `grid_scroll` event, appends the info for each one to a vector (via the tuple struct `GridScrollInfo`), and delivers that vector to the UI to handle each event, but it isn't perfect. Any feedback on alternatives (or anything else) is definitely welcome.