### PR TITLE
Fix inefficiency with ui attachment

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ extern crate webkit2gtk;
 
 use gio::prelude::*;
 
-use neovim_lib::neovim::{Neovim, UiAttachOptions};
+use neovim_lib::neovim::Neovim;
 use neovim_lib::session::Session as NeovimSession;
 use neovim_lib::NeovimApi;
 
@@ -120,17 +120,6 @@ fn build(app: &gtk::Application, opts: &Options) {
     let api_info = nvim.get_api_info().expect("Failed to get API info");
     nvim.set_var("gnvim_channel_id", api_info[0].clone())
         .expect("Failed to set g:gnvim_channel_id");
-
-    let mut ui_opts = UiAttachOptions::new();
-    ui_opts.set_rgb(true);
-    ui_opts.set_linegrid_external(true);
-    ui_opts.set_popupmenu_external(!opts.disable_ext_popupmenu);
-    ui_opts.set_tabline_external(!opts.disable_ext_tabline);
-    ui_opts.set_cmdline_external(!opts.disable_ext_cmdline);
-
-    ui_opts.set_wildmenu_external(true);
-    nvim.ui_attach(80, 30, &ui_opts)
-        .expect("Failed to attach UI");
 
     let ui = ui::UI::init(app, rx, Arc::new(Mutex::new(nvim)));
     ui.start();


### PR DESCRIPTION
Bfredl mentioned that there was an inefficency in how GNvim initializes the UI in https://github.com/vhakulinen/gnvim/issues/82#issuecomment-514729568. This commit fixes that according to his suggestion [here](https://github.com/vhakulinen/gnvim/issues/82#issuecomment-516729048).

This fixes #82 for me (with pango 1.43 at least; since pango 1.44 causes problems with GNvim, I downgraded pango to test if it fixed the issue). Apparently that slight inefficiency was the problem (Thanks @bfredl! 👏). That does need confirmation though, so if anyone can test this please do.

This isn't perfect, so feedback is appreciated; I imagine I probably missed something with the references and such, so if there's anything wrong there (or anywhere else), please let me know.

The current problem with this ATM is that none of the command line arguments to disable external features work, since I have defaulted to setting the external parts of the UI to true. Let me know how we want to go about fixing that.