### PR TITLE
Improve CLI Usage Error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use std::cell::RefCell;
 use std::process::Command;
 use std::rc::Rc;
 
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 
 include!(concat!(env!("OUT_DIR"), "/gnvim_version.rs"));
 
@@ -137,7 +137,24 @@ fn build(app: &gtk::Application, opts: &Options) {
 }
 
 fn main() {
-    let opts = Options::from_args();
+    let opts = Options::clap();
+    let opts =
+        Options::from_clap(&opts.get_matches_safe().unwrap_or_else(|err| {
+            if let clap::ErrorKind::UnknownArgument = err.kind {
+                // Arg likely passed for nvim, notify user of how to pass args to nvim.
+                clap::Error::with_description(
+                    &format!(
+                        "{}\nIf this is an argument for nvim, try moving \
+                         it after a -- separator.",
+                        err.message
+                    ),
+                    err.kind,
+                )
+                .exit()
+            } else {
+                err.exit()
+            }
+        }));
 
     let mut flags = gio::ApplicationFlags::empty();
     flags.insert(gio::ApplicationFlags::NON_UNIQUE);


### PR DESCRIPTION
See #99.

Only current problem is that the error message says `error:` twice (on the first line):
```bash
error: error: Found argument '--test' which wasn't expected, or isn't valid in this context

USAGE:
    gnvim [FLAGS] [OPTIONS] [FILES]... [-- <ARGS>...]

For more information try --help
If this is an argument for nvim, try moving it after a -- separator.
```

I could do some string splitting to remove the double `error:` strings, but I doubt that's the best way. AFAIK it's caused by me using the description of the error [here](https://github.com/smolck/gnvim/blob/4b680aadbc6cb52a88c6f30c09a4f58c6c1ee5a6/src/main.rs#L149), and then calling `exit()` (which I think puts the `error:` part at the start of the description automatically). I could of course just put the usual message without the `error:` at the front into an `&str` (which is probably the best course of action; let me know what you think).

Any suggestions/feedback/etc. (especially on how to remove the extra `error:`) are appreciated.