### PR TITLE
Fix panic when cell_at fails sometimes

### DIFF
--- a/src/ui/grid/grid.rs
+++ b/src/ui/grid/grid.rs
@@ -119,14 +119,15 @@ impl Grid {
         // cairo context.
         if ctx.cursor_blink_on == 0 {
             if let Some(row) = ctx.rows.get(ctx.cursor.0 as usize) {
-                let cell = row.cell_at(ctx.cursor.1 as usize + 1);
-                render::cursor_cell(
-                    &ctx.cursor_context,
-                    &self.da.get_pango_context().unwrap(),
-                    &cell,
-                    &ctx.cell_metrics,
-                    hl_defs,
-                );
+                if let Some(cell) = row.cell_at(ctx.cursor.1 as usize + 1) {
+                  render::cursor_cell(
+                      &ctx.cursor_context,
+                      &self.da.get_pango_context().unwrap(),
+                      &cell,
+                      &ctx.cell_metrics,
+                      hl_defs,
+                  );
+                }
             }
         }
 

--- a/src/ui/grid/row.rs
+++ b/src/ui/grid/row.rs
@@ -232,15 +232,16 @@ impl Rope {
     }
 
     /// Retruns single cell at `at`. Note that index starts at 1 and not 0.
-    pub fn cell_at(&self, at: usize) -> Cell {
+    pub fn cell_at(&self, at: usize) -> Option<Cell> {
         match self {
             Rope::Leaf(leaf) => {
-                let c = leaf.text.chars().nth(at - 1).unwrap();
-                Cell {
-                    text: c.to_string(),
-                    hl_id: leaf.hl_id,
-                    double_width: leaf.double_width,
-                }
+                leaf.text.chars().nth(at - 1).map(|c| {
+                  Cell {
+                      text: c.to_string(),
+                      hl_id: leaf.hl_id,
+                      double_width: leaf.double_width,
+                  }
+                })
             }
             Rope::Node(left, right) => {
                 let weight = left.weight();
@@ -330,7 +331,7 @@ impl Row {
         self.rope.as_ref().unwrap().leaf_at(at)
     }
 
-    pub fn cell_at(&self, at: usize) -> Cell {
+    pub fn cell_at(&self, at: usize) -> Option<Cell> {
         self.rope.as_ref().unwrap().cell_at(at)
     }
 
@@ -593,11 +594,11 @@ mod tests {
         let right = Rope::Leaf(Leaf::new(String::from("456"), 1, false));
         let rope = Rope::Node(Box::new(left), Box::new(right));
 
-        let cell = rope.cell_at(5);
+        let cell = rope.cell_at(5).unwrap();
         assert_eq!(cell.text, "5");
         assert_eq!(cell.hl_id, 1);
 
-        let cell = rope.cell_at(1);
+        let cell = rope.cell_at(1).unwrap();
         assert_eq!(cell.text, "1");
         assert_eq!(cell.hl_id, 0);
     }


### PR DESCRIPTION
`cell_at` caused panic sometimes when I was typing Japanese words.

I don't know what is the real reason but it can be fixed by remove the `unwrap` and turn the return value of `cell_at` into optional.