### PR TITLE
Fix #41

### DIFF
--- a/runtime/autoload/gnvim/popupmenu.vim
+++ b/runtime/autoload/gnvim/popupmenu.vim
@@ -10,3 +10,8 @@ function! gnvim#popupmenu#toggle_details()
     call rpcnotify(g:gnvim_channel_id, 'Gnvim', 'CompletionMenuToggleInfo')
     return ''
 endfunction
+
+function! gnvim#popupmenu#show_menu_on_all_items(bool)
+    call rpcnotify(g:gnvim_channel_id, 'Gnvim', 'PopupmenuShowMenuOnAllItems', a:bool)
+    return ''
+endfunction

--- a/src/nvim_bridge/mod.rs
+++ b/src/nvim_bridge/mod.rs
@@ -827,6 +827,7 @@ pub enum GnvimEvent {
 
     PopupmenuWidth(u64),
     PopupmenuWidthDetails(u64),
+    PopupmenuShowMenuOnAllItems(bool),
 
     Unknown(String),
 }
@@ -1155,6 +1156,23 @@ pub(crate) fn parse_gnvim_event(
             let w =
                 try_u64!(args.get(1).ok_or("width missing")?, "pmenu width");
             GnvimEvent::PopupmenuWidthDetails(w)
+        }
+        "PopupmenuShowMenuOnAllItems" => {
+            let show_menu_on_all = try_str!(
+                args.get(1).ok_or("bool missing")?,
+                "pmenu show menu on all items"
+            )
+            .parse::<bool>();
+
+            if let Err(err) = show_menu_on_all {
+                return Err(format!(
+                    "PopupmenuShowMenuOnAllItems event given a value other than
+                                    a bool: '{}'",
+                    err
+                ));
+            }
+
+            GnvimEvent::PopupmenuShowMenuOnAllItems(show_menu_on_all.unwrap())
         }
         _ => GnvimEvent::Unknown(String::from(cmd)),
     };

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -440,6 +440,9 @@ fn handle_gnvim_event(
         GnvimEvent::PopupmenuWidthDetails(width) => {
             state.popupmenu.set_width_details(*width as i32);
         }
+        GnvimEvent::PopupmenuShowMenuOnAllItems(should_show) => {
+            state.popupmenu.set_menu_on_all_items(*should_show);
+        }
         GnvimEvent::Unknown(msg) => {
             println!("Received unknown GnvimEvent: {}", msg);
         }
@@ -671,10 +674,11 @@ fn handle_redraw_event(
                         grid.get_rect_for_cell(popupmenu.row, popupmenu.col);
 
                     state.popupmenu.set_anchor(rect);
-                    state.popupmenu.show();
                     state
                         .popupmenu
                         .select(popupmenu.selected as i32, &state.hl_defs);
+
+                    state.popupmenu.show();
 
                     // If the cursor tooltip is visible at the same time, move
                     // it out of our way.


### PR DESCRIPTION
This uses a flag in the `Popupmenu` struct which can be set via RPC to determine whether or not the `menu` part of each _inactive_ (and active as well in most cases) `CompletionItem` is visible or not:

After `:call gnvim#popupmenu#show_menu_on_all_items("true")` has been run, no selection:

![image](https://user-images.githubusercontent.com/46855713/64923991-45ac3480-d7a5-11e9-872a-4c1c09535fc3.png)


Same as above but when __selecting an item and pressing `<C-s>`__:

![image](https://user-images.githubusercontent.com/46855713/64923993-4b097f00-d7a5-11e9-866c-a81f30a24ee5.png)

Same as above, but when __selecting an item without `<C-s>` being pressed__:

![image](https://user-images.githubusercontent.com/46855713/64923997-565caa80-d7a5-11e9-987f-49614c86e13e.png)

Currently the only issue I've noticed with this branch has been that when scrolling downwards _with the mouse_, things aren't updated until selected (which I'll look into hopefully later today, I have an idea of how to fix it):

![image](https://user-images.githubusercontent.com/46855713/64924060-06321800-d7a6-11e9-8b74-d6aa2d6ef0e6.png)

Any feedback (especially on the variable/function names I've used) is greatly appreciated. Not sure if a flag in the `Popupmenu` struct is how we want to do this, so if it's not let me know.

See #41.