### PR TITLE
Check whether working with valid index

### DIFF
--- a/src/ui/cmdline.rs
+++ b/src/ui/cmdline.rs
@@ -401,13 +401,17 @@ impl CmdlineInput {
         let buffer = self.textview.get_buffer().unwrap();
         let mut iter = buffer.get_start_iter();
 
-        let pos = self.content.split_at(self.cursor_pos).0.chars().count();
+        if self.content.as_bytes().len() > self.cursor_pos
+            && self.content.is_char_boundary(self.cursor_pos)
+        {
+            let pos = self.content.split_at(self.cursor_pos).0.chars().count();
 
-        iter.forward_chars(self.prompt_len + pos as i32);
-        buffer.place_cursor(&iter);
+            iter.forward_chars(self.prompt_len + pos as i32);
+            buffer.place_cursor(&iter);
 
-        let mark = buffer.create_mark(None, &iter, false).unwrap();
-        self.textview.scroll_to_mark(&mark, 0.1, false, 0.0, 0.0);
+            let mark = buffer.create_mark(None, &iter, false).unwrap();
+            self.textview.scroll_to_mark(&mark, 0.1, false, 0.0, 0.0);
+        }
     }
 
     fn set_line_space(&self, space: i64) {


### PR DESCRIPTION
This patch is a first draft for a bugfix where gnvim crashes when using
:Explore in $HOME (and also sometimes in non-$HOME).

It adds a check whether the value used to index
`self.content.split_at()` is within the buffer and at a valid unicode
boundary for the `String`.

---

Followup to the discussion in #43

This is a **draft**. I am not an expert on this unicode-stuff and neither am I for this codebase, so maybe we want to iterate on this patch a bit?