### PR TITLE
[WIP] Fix #85

### DIFF
--- a/src/ui/grid/context.rs
+++ b/src/ui/grid/context.rs
@@ -155,7 +155,7 @@ impl Context {
     }
 
     /// Returns x, y, width and height for current cursor location.
-    pub fn get_cursor_rect(&self) -> (f64, f64, f64, f64) {
+    pub fn get_cursor_rect(&self) -> (i32, i32, i32, i32) {
         let double_width = self
             .rows
             .get(self.cursor.0 as usize)
@@ -172,14 +172,14 @@ impl Context {
             self.cursor.1 as f64,
         );
         (
-            x,
-            y,
+            x.ceil() as i32,
+            y.ceil() as i32,
             if double_width {
-                cm.width * 2.0
+                (cm.width * 2.0).ceil() as i32
             } else {
-                cm.width
+                (cm.width).ceil() as i32
             },
-            cm.height,
+            cm.height.ceil() as i32,
         )
     }
 }

--- a/src/ui/grid/context.rs
+++ b/src/ui/grid/context.rs
@@ -204,10 +204,13 @@ impl CellMetrics {
             .get_metrics(Some(&self.font.as_pango_font()), None)
             .unwrap();
         let extra = self.line_space as f64 / 2.0;
-        self.ascent = fm.get_ascent() as f64 / pango::SCALE as f64 + extra;
-        self.decent = fm.get_descent() as f64 / pango::SCALE as f64 + extra;
-        self.height = self.ascent + self.decent;
-        self.width = (fm.get_approximate_digit_width() / pango::SCALE) as f64;
+        self.ascent =
+            (fm.get_ascent() as f64 / pango::SCALE as f64 + extra).ceil();
+        self.decent =
+            (fm.get_descent() as f64 / pango::SCALE as f64 + extra).ceil();
+        self.height = self.ascent + self.decent + self.line_space as f64;
+        self.width =
+            fm.get_approximate_char_width() as f64 / pango::SCALE as f64;
 
         self.underline_position =
             fm.get_underline_position() as f64 / pango::SCALE as f64 - extra;

--- a/src/ui/grid/grid.rs
+++ b/src/ui/grid/grid.rs
@@ -511,6 +511,7 @@ fn drawingarea_draw(cr: &cairo::Context, ctx: &mut Context) {
     // If we're not "busy", draw the cursor.
     if !ctx.busy {
         let (x, y, w, h) = ctx.get_cursor_rect();
+        let (x, y, w, h) = (x.ceil(), y.ceil(), w.ceil(), h.ceil());
 
         cr.save();
         cr.rectangle(x, y, w * ctx.cursor_cell_percentage, h);

--- a/src/ui/grid/grid.rs
+++ b/src/ui/grid/grid.rs
@@ -330,30 +330,20 @@ impl Grid {
 
         // Clear old cursor position.
         let (x, y, w, h) = ctx.get_cursor_rect();
-        ctx.queue_draw_area.push((
-            x.ceil() as i32,
-            y.ceil() as i32,
-            w.ceil() as i32,
-            h.ceil() as i32,
-        ));
+        ctx.queue_draw_area.push((x, y, w, h));
         ctx.cursor.0 = row;
         ctx.cursor.1 = col;
 
         // Mark the new cursor position to be drawn.
         let (x, y, w, h) = ctx.get_cursor_rect();
-        ctx.queue_draw_area.push((
-            x.ceil() as i32,
-            y.ceil() as i32,
-            w.ceil() as i32,
-            h.ceil() as i32,
-        ));
+        ctx.queue_draw_area.push((x, y, w, h));
 
         if let Some(ref im_context) = self.im_context {
             let rect = gdk::Rectangle {
-                x: x as i32,
-                y: y as i32,
-                width: w as i32,
-                height: h as i32,
+                x: x,
+                y: y,
+                width: w,
+                height: h,
             };
             im_context.set_cursor_location(&rect);
         }
@@ -455,8 +445,7 @@ impl Grid {
         // Don't use the ctx.queue_draw_area, because those draws will only
         // happen once nvim sends 'flush' event. This draw needs to happen
         // on each tick so the cursor blinks.
-        self.da
-            .queue_draw_area(x as i32, y as i32, w as i32, h as i32);
+        self.da.queue_draw_area(x, y, w, h);
     }
 
     /// Set a new font and line space. This will likely change the cell metrics.
@@ -511,13 +500,17 @@ fn drawingarea_draw(cr: &cairo::Context, ctx: &mut Context) {
     // If we're not "busy", draw the cursor.
     if !ctx.busy {
         let (x, y, w, h) = ctx.get_cursor_rect();
-        let (x, y, w, h) = (x.ceil(), y.ceil(), w.ceil(), h.ceil());
 
         cr.save();
-        cr.rectangle(x, y, w * ctx.cursor_cell_percentage, h);
+        cr.rectangle(
+            x as f64,
+            y as f64,
+            w as f64 * ctx.cursor_cell_percentage,
+            h as f64,
+        );
         let surface = ctx.cursor_context.get_target();
         surface.flush();
-        cr.set_source_surface(&surface, x, y);
+        cr.set_source_surface(&surface, x as f64, y as f64);
         cr.fill();
         cr.restore();
     }

--- a/src/ui/grid/grid.rs
+++ b/src/ui/grid/grid.rs
@@ -330,15 +330,23 @@ impl Grid {
 
         // Clear old cursor position.
         let (x, y, w, h) = ctx.get_cursor_rect();
-        ctx.queue_draw_area
-            .push((x as i32, y as i32, w as i32, h as i32));
+        ctx.queue_draw_area.push((
+            x.ceil() as i32,
+            y.ceil() as i32,
+            w.ceil() as i32,
+            h.ceil() as i32,
+        ));
         ctx.cursor.0 = row;
         ctx.cursor.1 = col;
 
         // Mark the new cursor position to be drawn.
         let (x, y, w, h) = ctx.get_cursor_rect();
-        ctx.queue_draw_area
-            .push((x as i32, y as i32, w as i32, h as i32));
+        ctx.queue_draw_area.push((
+            x.ceil() as i32,
+            y.ceil() as i32,
+            w.ceil() as i32,
+            h.ceil() as i32,
+        ));
 
         if let Some(ref im_context) = self.im_context {
             let rect = gdk::Rectangle {

--- a/src/ui/grid/render.rs
+++ b/src/ui/grid/render.rs
@@ -159,7 +159,12 @@ fn put_segments(
         let text = seg.leaf.text();
         render_text(cr, pango_context, cm, &hl, hl_defs, &text, x, y, w, h);
 
-        queue_draw_area.push((x as i32, y as i32, w as i32, h as i32));
+        queue_draw_area.push((
+            x.ceil() as i32,
+            y.ceil() as i32,
+            w.ceil() as i32,
+            h.ceil() as i32,
+        ));
     }
 }
 
@@ -304,8 +309,12 @@ pub fn scroll(ctx: &mut Context, hl_defs: &HlDefs, reg: [u64; 4], count: i64) {
     cr.set_operator(cairo::Operator::Source);
     cr.rectangle(x1, y1, w, h);
     cr.fill();
-    ctx.queue_draw_area
-        .push((x1 as i32, y1 as i32, w as i32, h as i32));
+    ctx.queue_draw_area.push((
+        x1.ceil() as i32,
+        y1.ceil() as i32,
+        w.ceil() as i32,
+        h.ceil() as i32,
+    ));
 
     // Clear the area that is left "dirty".
     let (x1, y1, x2, y2) = get_rect(
@@ -321,8 +330,12 @@ pub fn scroll(ctx: &mut Context, hl_defs: &HlDefs, reg: [u64; 4], count: i64) {
     cr.rectangle(x1, y1, x2 - x1, y2 - y1);
     cr.set_source_rgb(bg.r, bg.g, bg.b);
     cr.fill();
-    ctx.queue_draw_area
-        .push((x1 as i32, y1 as i32, w as i32, h as i32));
+    ctx.queue_draw_area.push((
+        x1.ceil() as i32,
+        y1.ceil() as i32,
+        w.ceil() as i32,
+        h.ceil() as i32,
+    ));
 
     cr.restore();
 }


### PR DESCRIPTION
This is fairly close to working, but it has visual artifacts (and the font looks a bit blurred to me, but maybe not for everyone?):

![image](https://user-images.githubusercontent.com/46855713/69908666-edec9500-13b3-11ea-9b2c-caf043685344.png)

Interestingly, they disappear after opening the cmdline (so after typing `:`):

![image](https://user-images.githubusercontent.com/46855713/69908668-06f54600-13b4-11ea-9367-84c9c13d9f25.png)

The line that's causing this "reset" of the artifacts is here (see https://github.com/vhakulinen/gnvim/issues/85#issuecomment-560044135): https://github.com/vhakulinen/gnvim/blob/65846f45020b338fedd932b058c9e8036dadd976/src/ui/cmdline.rs#L575

But I have no idea why calling `show_all` on a `gtk::Fixed` removes the artifacts. Any ideas?

The artifacts appear to be coming from a lack of subpixel positioning in GNvim, but I could be wrong. Note that when I `ceil` (or `floor`) the `width` value of the `CellMetrics` the artifacts disappear, but the cursor is no longer positioned correctly. (All this still doesn't explain the "reset" when opening the cmdline though.)

cc: @vhakulinen @last-partizan