### PR TITLE
Makefile: install on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ syntect-pack:
 
 install:
 	install -d "$(DESTDIR)$(PREFIX)/bin"
-	install -t "$(DESTDIR)$(PREFIX)/bin" ./target/release/gnvim
+	install ./target/release/gnvim "$(DESTDIR)$(PREFIX)/bin"
 	install -d "$(DESTDIR)$(PREFIX)/share/gnvim"
 	cp -r ./runtime "$(DESTDIR)$(PREFIX)/share/gnvim"
 	install -d "$(DESTDIR)$(PREFIX)/share/applications"


### PR DESCRIPTION
somehow install utility works differently on FreeBSD. This commit makes build && install process seamless on FreeBSD machine

I do not have linux box with UI right now, so cannot test with new Makefile on linux. If somebody can - it would be great