### PR TITLE
Implement smooth scrolling support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ rmpv = "0.4"
 
 [dependencies.gtk]
 version = "0.9"
-features = ["v3_18"]
+features = ["v3_24"]
 
 [dependencies.webkit2gtk]
 version = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ rmpv = "0.4"
 
 [dependencies.gtk]
 version = "0.9"
-features = ["v3_24"]
+features = ["v3_18"]
 
 [dependencies.webkit2gtk]
 version = "0.10"

--- a/src/ui/grid/grid.rs
+++ b/src/ui/grid/grid.rs
@@ -212,40 +212,41 @@ impl Grid {
 
         // NOTE(ville): Once we bump gtk from 3.18 to 3.24, use GtkEventControllerScroll
         // to improve smooth scrolling (ref #175).
-        self.eb.connect_scroll_event(clone!(ctx, scroll_dy => move |_, e| {
-            let ctx = ctx.borrow_mut();
-            let dir = match e.get_direction() {
-                gdk::ScrollDirection::Up => ScrollDirection::Up,
-                gdk::ScrollDirection::Down => ScrollDirection::Down,
-                gdk::ScrollDirection::Smooth => {
-                    // Smooth scrolling. During scroll, many little deltas are
-                    // accumulated in scroll_dy. Once it reaches -1.0 (scroll up)
-                    // or +1.0 (scroll down), scroll_dy is reset and the scroll
-                    // operation is made effective.
-                    let (_, smooth_dy) = e.get_scroll_deltas().unwrap();
-                    let prev_dy = *scroll_dy.borrow();
-                    let dy = prev_dy + smooth_dy;
-                    if dy <= -1.0 {
-                        *scroll_dy.borrow_mut() = 0.0;
-                        ScrollDirection::Up
-                    } else if dy >= 1.0 {
-                        *scroll_dy.borrow_mut() = 0.0;
-                        ScrollDirection::Down
-                    } else {
-                        // Don't scroll yet.
-                        *scroll_dy.borrow_mut() = dy;
-                        return Inhibit(false);
-                    }
-                },
-                _ => { return Inhibit(false); },
-            };
+        self.eb
+            .connect_scroll_event(clone!(ctx, scroll_dy => move |_, e| {
+                let ctx = ctx.borrow_mut();
+                let dir = match e.get_direction() {
+                    gdk::ScrollDirection::Up => ScrollDirection::Up,
+                    gdk::ScrollDirection::Down => ScrollDirection::Down,
+                    gdk::ScrollDirection::Smooth => {
+                        // Smooth scrolling. During scroll, many little deltas are
+                        // accumulated in scroll_dy. Once it reaches -1.0 (scroll up)
+                        // or +1.0 (scroll down), scroll_dy is reset and the scroll
+                        // operation is made effective.
+                        let (_, smooth_dy) = e.get_scroll_deltas().unwrap();
+                        let prev_dy = *scroll_dy.borrow();
+                        let dy = prev_dy + smooth_dy;
+                        if dy <= -1.0 {
+                            *scroll_dy.borrow_mut() = 0.0;
+                            ScrollDirection::Up
+                        } else if dy >= 1.0 {
+                            *scroll_dy.borrow_mut() = 0.0;
+                            ScrollDirection::Down
+                        } else {
+                            // Don't scroll yet.
+                            *scroll_dy.borrow_mut() = dy;
+                            return Inhibit(false);
+                        }
+                    },
+                    _ => { return Inhibit(false); },
+                };
 
-            let pos = e.get_position();
-            let col = (pos.0 / ctx.cell_metrics.width).floor() as u64;
-            let row = (pos.1 / ctx.cell_metrics.height).floor() as u64;
+                let pos = e.get_position();
+                let col = (pos.0 / ctx.cell_metrics.width).floor() as u64;
+                let row = (pos.1 / ctx.cell_metrics.height).floor() as u64;
 
-            f(dir, row, col)
-        }));
+                f(dir, row, col)
+            }));
     }
 
     /// Connects `f` to internal widget's motion events. `f` params are button,


### PR DESCRIPTION
Scrolling with the touchpad had no effect. It seemed scrolling events
were purely ignored. As explained in #70, this is due to smooth
scrolling. The problem with enabling smooth scrolling is that it
generates a lot of scrolling events, resulting in overly fast scroll
without further processing.

The solution here consists in hooking on the "start scroll" event to
reset a scrolling counter (this requires to bump the GTK version). When
the scrolling is hapening, this counter is incremented with the
scrolling deltas.  When it reaches -1.0 or +1.0 (which is the value that
"normal scrolling" sends), we trigger a scrolling event (down or up,
depending on the sign) and reset the counter.

Overall, it enables scrolling in gnvim with the touchpad.

This probably fixes #70.