### PR TITLE
Added keyname translation for space key

### DIFF
--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -331,6 +331,7 @@ fn keyname_to_nvim_key(s: &str) -> Option<&str> {
         "greater" => Some(">"),
         "comma" => Some(","),
         "period" => Some("."),
+        "space" => Some("Space"),
         "BackSpace" => Some("BS"),
         "Insert" => Some("Insert"),
         "Return" => Some("CR"),


### PR DESCRIPTION
As brought up in https://github.com/vhakulinen/gnvim/issues/164 keymappings onto `<C-Space>` do not work when using gnvim. As this is a nice thing to have especially for toggeling something like gitgutter with an super accessible key like Space I went into the code an saw that the `keyname_to_nvim_key` function in `ui.rs` did not contain a mapping for the "space" keyname. I added this one in and for the testcase described below it works like a charm.

Minimal setup for testing:
```sh
$ cargo run -- -- -u NONE
:nnoremap <C-Space> :vsplit<cr>
<C-Space>
```