### PR TITLE
Update gtk4 install hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _For previous gtk3 version, checkout the `legacy` branch._
 
 ```
 $ # Install cargo (e.g. the rust toolchain)
-$ # Install gtk4 dev files, e.g. apt install gtk-4-dev
+$ # Install gtk4 dev files, e.g. apt install libgtk-4-dev
 $ make build
 $ sudo make install
 ```


### PR DESCRIPTION
I could not find a reference to gtk-4-dev in any Debian based repositories.