### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Gnvim, opinionated Neovim GUI.
 
 _For previous gtk3 version, checkout the `legacy` branch._
 
+# Prerequisite 
+
+Before building the application, install `gtk4` following instructions from https://gtk-rs.org/gtk4-rs/stable/latest/book/installation.html
+
 # Install
 
 ```


### PR DESCRIPTION
# What?
Added Prerequisite section before building application.

# Why?
Application failed building with below error as i was not having gtk4 installed.

```
The following warnings were emitted during compilation:

warning: `"pkg-config" "--libs" "--cflags" "graphene-gobject-1.0" "graphene-gobject-1.0 >= 1.10"` did not exit successfully: exit status: 1

error: failed to run custom build command for `graphene-sys v0.15.10`

Caused by:
  process didn't exit successfully: `/Users/prabhugopal/Tools/gnvim/target/release/build/graphene-sys-bbbcd53a7cd6b338/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=GRAPHENE_GOBJECT_1.0_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:warning=`"pkg-config" "--libs" "--cflags" "graphene-gobject-1.0" "graphene-gobject-1.0 >= 1.10"` did not exit successfully: exit status: 1
  error: could not find system library 'graphene-gobject-1.0' required by the 'graphene-sys' crate

  --- stderr
  Package graphene-gobject-1.0 was not found in the pkg-config search path.
  Perhaps you should add the directory containing `graphene-gobject-1.0.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'graphene-gobject-1.0' found
  Package graphene-gobject-1.0 was not found in the pkg-config search path.
  Perhaps you should add the directory containing `graphene-gobject-1.0.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'graphene-gobject-1.0' found

error: failed to run custom build command for `gdk4-sys v0.4.2`

Caused by:
  process didn't exit successfully: `/Users/prabhugopal/Tools/gnvim/target/release/build/gdk4-sys-38dfda58e2872796/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=GTK4_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr
  `"pkg-config" "--libs" "--cflags" "gtk4" "gtk4 >= 4.3.2"` did not exit successfully: exit status: 1
  error: could not find system library 'gtk4' required by the 'gdk4-sys' crate

  --- stderr
  Package gtk4 was not found in the pkg-config search path.
  Perhaps you should add the directory containing `gtk4.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'gtk4' found
  Package gtk4 was not found in the pkg-config search path.
  Perhaps you should add the directory containing `gtk4.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'gtk4' found

make: *** [build] Error 101

```


