### PR TITLE
RFC / DRAFT: Add release-debug, optimized, and optimized-debug build profiles.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,30 @@ members = [
     "lib/nvim-rs",
     "lib/gio-compat",
 ]
+
+# https://doc.rust-lang.org/cargo/reference/profiles.html
+
+# Release build with full debug symbols for backtraces and interactive
+# debugger sessions etc.
+[profile.release-debug]
+inherits = "release"
+debug = true
+
+# When compared to the 'release' profile, this reduces the code size by ~45% at
+# the cost of increasing build times by ~10%. Should increase runtime
+# performance somewhat too.
+[profile.optimized]
+inherits = "release"
+lto = true
+codegen-units = 1
+
+# Full debug info and runtime checks, but otherwise with max code performance.
+# This can be useful for debugging issues if the normal 'dev' build profile
+# generates code which is either too slow to use, or which changes behaviour
+# with respect to runtime race conditions.
+[profile.optimized-debug]
+inherits = "dev"
+opt-level = 3
+lto = true
+codegen-units = 1
+incremental = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "lib/gio-compat",
 ]
 
+# For addition information about build profies, see
 # https://doc.rust-lang.org/cargo/reference/profiles.html
 
 # Release build with full debug symbols for backtraces and interactive
@@ -31,3 +32,11 @@ opt-level = 3
 lto = true
 codegen-units = 1
 incremental = false
+
+# Enable small amount of optimizations for dev builds.
+[profile.dev]
+opt-level = 1
+
+# Enable high optimizations for dependencies even on dev builds.
+[profile.dev.package."*"]
+opt-level = 3

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,17 @@ ifeq ($(PREFIX),)
     PREFIX := /usr/local
 endif
 
+# Rust build profile.  See Cargo.toml for alternatives.
+ifeq ($(PROFILE),)
+    PROFILE := optimized
+endif
+
 build:
-	cargo build --release
+	cargo build --profile $(PROFILE)
 
 install:
 	install -d "$(DESTDIR)$(PREFIX)/bin"
-	install ./target/release/gnvim "$(DESTDIR)$(PREFIX)/bin"
+	install ./target/$(PROFILE)/gnvim "$(DESTDIR)$(PREFIX)/bin"
 	install -d "$(DESTDIR)$(PREFIX)/share/gnvim"
 	cp -r ./runtime "$(DESTDIR)$(PREFIX)/share/gnvim"
 	install -d "$(DESTDIR)$(PREFIX)/share/applications"


### PR DESCRIPTION
I've done a bit of rust development on bare metal embedded systems, where I usually tweak the default cargo release build profile for minimum code size.  I thought I would try the same on gnvim, and it reduced the generated code size by 45% whilst only adding 10% to the compile time.   I thought this was probably worth having, so here's a PR which introduces this build profile, and changes the Makefile to use it by default.

There are also a couple of other profiles which I've used in the past for debug builds for troubleshooting, which I thought could provide a straightforward way to help users debug issue.